### PR TITLE
Always return a searchURL

### DIFF
--- a/Sources/itunes_missing_artwork/MissingArtwork+MusicAPI.swift
+++ b/Sources/itunes_missing_artwork/MissingArtwork+MusicAPI.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension MissingArtwork {
-    var searchURL : URL? {
+    var searchURL : URL {
         var urlComponents = URLComponents()
         urlComponents.scheme = "https"
         urlComponents.host = "api.music.apple.com"
@@ -16,6 +16,9 @@ extension MissingArtwork {
         urlComponents.queryItems = [URLQueryItem(name: "term", value: self.simpleRepresentation),
                                     URLQueryItem(name: "types", value: "albums"),
                                     URLQueryItem(name: "limit", value: "2")]
-        return urlComponents.url
+        if let url = urlComponents.url {
+            return url
+        }
+        return URL(string: "missing")! // Use an bogus URL and allow the networking layer return an error.
     }
 }

--- a/Sources/itunes_missing_artwork/main.swift
+++ b/Sources/itunes_missing_artwork/main.swift
@@ -39,21 +39,19 @@ struct Generate : ParsableCommand {
         var cancellables : [AnyCancellable] = []
 
         for missingMediaArtwork in missingMediaArtworks.sorted() {
-            if let searchURL = missingMediaArtwork.searchURL {
-                let cancellable = session.musicAPIImageURLPublisher(searchURL: searchURL)
-                    .sink { completion in
-                        switch completion {
-                        case let .failure(reason):
-                            print("media: \(missingMediaArtwork) failed: \(reason)")
-                        case .finished:
-                            break
-                        }
-                    } receiveValue: { urls in
-                        print("media: \(missingMediaArtwork) imageURLs: \(String(describing: urls))")
+            let cancellable = session.musicAPIImageURLPublisher(searchURL: missingMediaArtwork.searchURL)
+                .sink { completion in
+                    switch completion {
+                    case let .failure(reason):
+                        print("media: \(missingMediaArtwork) failed: \(reason)")
+                    case .finished:
+                        break
                     }
+                } receiveValue: { urls in
+                    print("media: \(missingMediaArtwork) imageURLs: \(String(describing: urls))")
+                }
 
-                cancellables.append(cancellable)
-            }
+            cancellables.append(cancellable)
         }
 
         RunLoop.main.run()


### PR DESCRIPTION
If it cannot be created, return a bogus one. This way the networking layer will fail instead of handling this optional.