### PR TITLE
Add DescriptionList UI

### DIFF
--- a/Sources/MissingArtwork/MissingArtwork.swift
+++ b/Sources/MissingArtwork/MissingArtwork.swift
@@ -24,6 +24,12 @@ extension MissingArtwork: CustomStringConvertible {
   }
 }
 
+extension MissingArtwork: Identifiable {
+  public var id: String {
+    self.simpleRepresentation
+  }
+}
+
 extension MissingArtwork {
   var simpleRepresentation: String {
     switch self {

--- a/Sources/MissingArtworkUI/DescriptionList.swift
+++ b/Sources/MissingArtworkUI/DescriptionList.swift
@@ -1,0 +1,36 @@
+//
+//  DescriptionList.swift
+//
+//
+//  Created by Greg Bolsinga on 4/19/22.
+//
+
+import MissingArtwork
+import SwiftUI
+
+public struct DescriptionList: View {
+  public init(missingArtworks: [MissingArtwork]) {
+    self.missingArtworks = missingArtworks
+  }
+
+  let missingArtworks: [MissingArtwork]
+
+  public var body: some View {
+    List {
+      ForEach(missingArtworks) { missingArtwork in
+        Description(missingArtwork: missingArtwork)
+      }
+    }
+  }
+}
+
+struct DescriptionList_Previews: PreviewProvider {
+  static var previews: some View {
+    let missingArtworks = [
+      MissingArtwork.ArtistAlbum("The Stooges", "Fun House"),
+      .CompilationAlbum("Beleza Tropical: Brazil Classics 1"),
+    ]
+
+    DescriptionList(missingArtworks: missingArtworks)
+  }
+}


### PR DESCRIPTION
Requires making MissingArtwork enum Identifiable.