### PR TITLE
Unblock the main thread when reading itunes library

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -109,7 +109,7 @@ public struct DescriptionList: View {
       Text("Select an Item")
     }
     .task {
-      model.fetchMissingArtworks()
+      await model.fetchMissingArtworks()
     }
   }
 }

--- a/Sources/MissingArtwork/Model.swift
+++ b/Sources/MissingArtwork/Model.swift
@@ -27,9 +27,11 @@ public class Model: ObservableObject {
     self.init(missingArtworks: [])
   }
 
-  public func fetchMissingArtworks() {
+  public func fetchMissingArtworks() async {
     do {
-      self.missingArtworks = Array(Set<MissingArtwork>(try MissingArtwork.gatherMissingArtwork()))
+      async let missingArtworks = try MissingArtwork.gatherMissingArtwork()
+
+      self.missingArtworks = try await Array(Set<MissingArtwork>(missingArtworks))
     } catch {
       debugPrint("Unable to fetch missing artworks: \(error)")
       self.missingArtworks = []

--- a/Sources/MissingArtworkTool/Program.swift
+++ b/Sources/MissingArtworkTool/Program.swift
@@ -32,7 +32,7 @@ struct Program: AsyncParsableCommand {
       .sign(with: signingData.p8)
 
     let model = Model()
-    model.fetchMissingArtworks()
+    await model.fetchMissingArtworks()
     let missingMediaArtworks = model.missingArtworks
     print("\(missingMediaArtworks.count) Missing Artworks")
 


### PR DESCRIPTION
get the data from itunes with async let. No longer get the spinning beach ball on the UI while the data loads.