### PR TITLE
Move MissingArtworkList .task to parent

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -103,7 +103,10 @@ public struct DescriptionList: View {
         List(selection: $selectedArtwork) {
           ForEach(displayableArtworks) { missingArtwork in
             NavigationLink {
-              MissingImageList(missingArtwork: missingArtwork, token: token)
+              MissingImageList(missingArtwork: missingArtwork)
+                .task {
+                  await model.fetchImageURLs(missingArtwork: missingArtwork, token: token)
+                }
             } label: {
               Description(missingArtwork: missingArtwork)
             }

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -11,7 +11,6 @@ struct MissingImageList: View {
   @EnvironmentObject var model: Model
 
   let missingArtwork: MissingArtwork
-  let token: String
 
   struct IdentifiableURL: Identifiable {
     public let url: URL
@@ -40,9 +39,6 @@ struct MissingImageList: View {
         ProgressView()
       }
     }.overlay(progressOverlay)
-      .task {
-        await model.fetchImageURLs(missingArtwork: missingArtwork, token: token)
-      }
   }
 }
 
@@ -50,8 +46,8 @@ struct MissingImageList_Previews: PreviewProvider {
   static var previews: some View {
     let model = Model.preview
     Group {
-      MissingImageList(missingArtwork: model.missingArtworks.first!, token: "")
-      MissingImageList(missingArtwork: model.missingArtworks.last!, token: "")
+      MissingImageList(missingArtwork: model.missingArtworks.first!)
+      MissingImageList(missingArtwork: model.missingArtworks.last!)
     }
     .environmentObject(model)
   }


### PR DESCRIPTION
- This way it does not have to know about the token nor how the image URLs are obtained.