### PR TITLE
just the parts not the Model in previews

### DIFF
--- a/Sources/MissingArtwork/Description.swift
+++ b/Sources/MissingArtwork/Description.swift
@@ -38,10 +38,9 @@ public struct Description: View {
 
 struct Description_Previews: PreviewProvider {
   static var previews: some View {
-    let model = Model.preview
     Group {
-      Description(missingArtwork: model.missingArtworks[0])
-      Description(missingArtwork: model.missingArtworks[1])
+      Description(missingArtwork: Model.previewArtworks[0])
+      Description(missingArtwork: Model.previewArtworks[1])
     }
   }
 }

--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -171,11 +171,10 @@ struct DescriptionList_Previews: PreviewProvider {
   }
 
   static var previews: some View {
-    let model = Model.preview
     DescriptionList(
       fetcher: Fetcher(),
-      missingArtworks: .constant(model.missingArtworks),
-      missingArtworkURLs: .constant(model.missingArtworkURLs)
+      missingArtworks: .constant(Model.previewArtworks),
+      missingArtworkURLs: .constant(Model.previewArtworkHashURLs)
     )
   }
 }

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -43,13 +43,12 @@ struct MissingImageList: View {
 struct MissingImageList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      let model = Model.preview
       MissingImageList(
-        missingArtwork: model.missingArtworks.first!,
-        urls: .constant(model.missingArtworkURLs[model.missingArtworks.first!]))
+        missingArtwork: Model.previewArtworks.first!,
+        urls: .constant(Model.previewArtworkURLs.first))
       MissingImageList(
-        missingArtwork: model.missingArtworks.last!,
-        urls: .constant(model.missingArtworkURLs[model.missingArtworks.last!]))
+        missingArtwork: Model.previewArtworks.last!,
+        urls: .constant(Model.previewArtworkURLs.last))
     }
   }
 }

--- a/Sources/MissingArtwork/Preview Content/ModelData.swift
+++ b/Sources/MissingArtwork/Preview Content/ModelData.swift
@@ -8,12 +8,13 @@
 import Foundation
 
 extension Model {
-  public static let preview = Model(
-    missingArtworks: [
-      MissingArtwork.ArtistAlbum("The Stooges", "Fun House"),
-      .CompilationAlbum("Beleza Tropical: Brazil Classics 1"),
-    ],
-    urls: [
+  public static let previewArtworks = [
+    MissingArtwork.ArtistAlbum("The Stooges", "Fun House"),
+    MissingArtwork.CompilationAlbum("Beleza Tropical: Brazil Classics 1"),
+  ]
+
+  public static let previewArtworkURLs =
+    [
       [
         URL(
           string:
@@ -30,5 +31,10 @@ extension Model {
             "https://is3-ssl.mzstatic.com/image/thumb/Music124/v4/e4/56/8d/e4568db1-d583-4456-7d44-e557fd887538/mzi.ritwbkcw.jpg/1425x1425bb.jpg"
         )!
       ],
-    ])
+    ]
+
+  public static let previewArtworkHashURLs = [
+    previewArtworks.first!: previewArtworkURLs.first!,
+    previewArtworks.last!: previewArtworkURLs.last!,
+  ]
 }


### PR DESCRIPTION
- this way the async parts of the Model do not need to be protected from running again!
- this will allow more flexibility in how the Model is used, and keep previews out of the Model business.