### PR TITLE
Use @State to track if progress overlay is shown on DescriptionList

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -29,6 +29,7 @@ struct DescriptionList: View {
 
   @Binding var missingArtworks: [MissingArtwork]
   @Binding var missingArtworkURLs: [MissingArtwork: [URL]]
+  @Binding var showProgressOverlay: Bool
 
   var displayableArtworks: [MissingArtwork] {
     return missingArtworks.filter { missingArtwork in
@@ -91,7 +92,7 @@ struct DescriptionList: View {
   }
 
   @ViewBuilder private var progressOverlay: some View {
-    if displayableArtworks.count == 0 {
+    if showProgressOverlay {
       ProgressView()
     }
   }
@@ -175,7 +176,15 @@ struct DescriptionList_Previews: PreviewProvider {
     DescriptionList(
       fetcher: Fetcher(),
       missingArtworks: .constant(Model.previewArtworks),
-      missingArtworkURLs: .constant(Model.previewArtworkHashURLs)
+      missingArtworkURLs: .constant(Model.previewArtworkHashURLs),
+      showProgressOverlay: .constant(false)
+    )
+
+    DescriptionList(
+      fetcher: Fetcher(),
+      missingArtworks: .constant([]),
+      missingArtworkURLs: .constant([:]),
+      showProgressOverlay: .constant(true)
     )
   }
 }

--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 public struct MissingArtworkView: View, ImageURLFetcher {
   let token: String
 
+  @State private var showProgressOverlay: Bool = true
+
   @StateObject private var model = Model()
 
   public init(token: String) {
@@ -20,10 +22,13 @@ public struct MissingArtworkView: View, ImageURLFetcher {
     DescriptionList(
       fetcher: self,
       missingArtworks: $model.missingArtworks,
-      missingArtworkURLs: $model.missingArtworkURLs
+      missingArtworkURLs: $model.missingArtworkURLs,
+      showProgressOverlay: $showProgressOverlay
     )
     .task {
+      showProgressOverlay = true
       await model.fetchMissingArtworks(token: token)
+      showProgressOverlay = false
     }
   }
 

--- a/Sources/MissingArtwork/Model.swift
+++ b/Sources/MissingArtwork/Model.swift
@@ -31,11 +31,6 @@ public class Model: ObservableObject {
         async let missingArtworks = try MissingArtwork.gatherMissingArtwork()
 
         self.missingArtworks = try await Array(Set<MissingArtwork>(missingArtworks))
-
-        for missingArtwork in self.missingArtworks {
-          await fetchImageURLs(
-            missingArtwork: missingArtwork, term: missingArtwork.simpleRepresentation, token: token)
-        }
       } catch {
         debugPrint("Unable to fetch missing artworks: \(error)")
         self.missingArtworks = []


### PR DESCRIPTION
- The state is tracked in the parent of DescriptionList, but read within it. This is because DescriptionList does not know how to load things, and having it track how many things there were to show progress or not seemed to be an issue. Basically I want to be able to tease out the state independent of the Model array. I want to show errors and show if there is just nothing to show.
- this has the task set to show the progress overly while the data is loading from iTunes
- it stops pre-loading the artwork URLs for now, as then the method did not return quickly. Basicalliy a minor revert of #56. It will in a subsequent change.