### PR TITLE
asynchronously fetch the image urls again

### DIFF
--- a/Sources/MissingArtwork/Model.swift
+++ b/Sources/MissingArtwork/Model.swift
@@ -30,6 +30,13 @@ public class Model: ObservableObject {
       async let missingArtworks = try MissingArtwork.gatherMissingArtwork()
 
       self.missingArtworks = try await Array(Set<MissingArtwork>(missingArtworks))
+
+      Task.detached {
+        for missingArtwork in await self.missingArtworks {
+          await self.fetchImageURLs(
+            missingArtwork: missingArtwork, term: missingArtwork.simpleRepresentation, token: token)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
restore async url fetch removed in #83 originally added in #56.
this is a better way to do this - func returns sooner, and this still happens in the "background"