### PR TITLE
Move overlay logic to parent view

### DIFF
--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -20,15 +20,6 @@ struct MissingImageList: View {
     urls.map { $0.map { IdentifiableURL(url: $0) } }
   }
 
-  @ViewBuilder private var progressOverlay: some View {
-    if identifiableURLs == nil {
-      ProgressView()
-    } else if let identifiableURLs = identifiableURLs, identifiableURLs.count == 0 {
-      Text("No image for \(missingArtwork.description)")
-        .textSelection(.enabled)
-    }
-  }
-
   var body: some View {
     List(self.identifiableURLs ?? []) { item in
       AsyncImage(url: item.url) { image in
@@ -36,7 +27,7 @@ struct MissingImageList: View {
       } placeholder: {
         ProgressView()
       }
-    }.overlay(progressOverlay)
+    }
   }
 }
 


### PR DESCRIPTION
- Instead of having MissingImageList manage its overlay, have DescriptionList manage it.
- This is becase DescriptionList is doing the loading, and can manage the state during the load.
- This allows errors to be caught and displayed in the message text for a subsequent diff.