### PR TITLE
fetchImageURLs now throws

### DIFF
--- a/Sources/MissingArtwork/ArtworkURLFetcher.swift
+++ b/Sources/MissingArtwork/ArtworkURLFetcher.swift
@@ -80,8 +80,13 @@ public struct ArtworkURLFetcher {
       throw FetcherError.badRequest
     }
 
-    let music = try JSONDecoder().decode(MusicResponse.self, from: data)  // decode the data
-    return music.results.albums.data.compactMap { $0.attributes.artwork.imageURL }  // Convert the array of results into an array of URLs
+    do {
+      let music = try JSONDecoder().decode(MusicResponse.self, from: data)  // decode the data
+      return music.results.albums.data.compactMap { $0.attributes.artwork.imageURL }  // Convert the array of results into an array of URLs
+    } catch {
+      debugPrint("Unable to fetch missing artwork URLs: (\(searchURL)) - \(error)")
+      return []
+    }
   }
 
   public func fetch(searchTerm: String) async throws -> [URL] {

--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -81,8 +81,8 @@ public struct MissingArtworkView: View, ImageURLFetcher {
     .musicKitAuthorizationSheet()
   }
 
-  func fetchImages(missingArtwork: MissingArtwork, term: String) async {
-    await model.fetchImageURLs(
+  func fetchImages(missingArtwork: MissingArtwork, term: String) async throws {
+    try await model.fetchImageURLs(
       missingArtwork: missingArtwork, term: term, token: token)
   }
 }

--- a/Sources/MissingArtwork/Model.swift
+++ b/Sources/MissingArtwork/Model.swift
@@ -33,22 +33,17 @@ public class Model: ObservableObject {
 
       Task.detached {
         for missingArtwork in await self.missingArtworks {
-          await self.fetchImageURLs(
+          try await self.fetchImageURLs(
             missingArtwork: missingArtwork, term: missingArtwork.simpleRepresentation, token: token)
         }
       }
     }
   }
 
-  func fetchImageURLs(missingArtwork: MissingArtwork, term: String, token: String) async {
+  func fetchImageURLs(missingArtwork: MissingArtwork, term: String, token: String) async throws {
     if self.missingArtworkURLs[missingArtwork] == nil {
-      let fetcher = ArtworkURLFetcher(token: token)
-      do {
-        self.missingArtworkURLs[missingArtwork] = try await fetcher.fetch(searchTerm: term)
-      } catch {
-        debugPrint("Unable to fetch missing artwork URLs: (\(missingArtwork)) - \(error)")
-        self.missingArtworkURLs[missingArtwork] = []
-      }
+      self.missingArtworkURLs[missingArtwork] = try await ArtworkURLFetcher(token: token).fetch(
+        searchTerm: term)
     }
   }
 }


### PR DESCRIPTION
- This way it will end the async task of looking for items right away when an error is thrown.
- Now when the user does an action that causes an error, it will display (just as if there were zero items found).
- the empty json will not return the empty array at the source instead of catching the error higher up.
-- this allows that other errors, which are more important are made known.
- found by a rough patch of trying out MusicKit which was throwing an error early and repeatedly on the async portion.