### PR TITLE
Revert "asynchronously fetch the image urls again (#87)"

### DIFF
--- a/Sources/MissingArtwork/Model.swift
+++ b/Sources/MissingArtwork/Model.swift
@@ -31,13 +31,6 @@ public class Model: ObservableObject {
       async let missingArtworks = try MissingArtwork.gatherMissingArtwork()
 
       self.missingArtworks = try await Array(Set<MissingArtwork>(missingArtworks))
-
-      Task.detached {
-        for missingArtwork in await self.missingArtworks {
-          try await self.fetchImageURLs(
-            missingArtwork: missingArtwork, term: missingArtwork.simpleRepresentation)
-        }
-      }
     }
   }
 


### PR DESCRIPTION
This reverts commit b16865ccfaa24e4ce990d3d498a12d2641c84a02.

if not yet authorized for MusicKit by the user, this will fail. It needs to observe the auth status, after the missing artworks are found from iTunes.