### PR TITLE
Allow client to configure what is done with partial album images

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -20,6 +20,7 @@ protocol ArtworksFetcher {
 
 struct DescriptionList: View {
   let fetcher: ArtworksFetcher
+  let partialImageButtonBuilder: (_ missingArtwork: MissingArtwork) -> Button<Text>
 
   @State private var filter = FilterCategory.all
   @State private var sortOrder = SortOrder.ascending
@@ -166,6 +167,10 @@ struct DescriptionList: View {
             } label: {
               Description(missingArtwork: missingArtwork, availability: availability)
             }
+            .contextMenu {
+              self.partialImageButtonBuilder(missingArtwork)
+                .disabled(availability != .some)
+            }
             .tag(missingArtwork)
           }
         }
@@ -234,6 +239,9 @@ struct DescriptionList_Previews: PreviewProvider {
   static var previews: some View {
     DescriptionList(
       fetcher: Fetcher(),
+      partialImageButtonBuilder: { missingArtwork in
+        Button("") {}
+      },
       missingArtworks: .constant([
         (MissingArtwork.ArtistAlbum("The Stooges", "Fun House"), .none),
         (MissingArtwork.CompilationAlbum("Beleza Tropical: Brazil Classics 1"), .some),
@@ -244,6 +252,10 @@ struct DescriptionList_Previews: PreviewProvider {
 
     DescriptionList(
       fetcher: Fetcher(),
+      partialImageButtonBuilder: { missingArtwork in
+        Button("") {
+        }
+      },
       missingArtworks: .constant([]),
       artworks: .constant([:]),
       showProgressOverlay: .constant(true)

--- a/Sources/MissingArtwork/MissingArtwork.swift
+++ b/Sources/MissingArtwork/MissingArtwork.swift
@@ -36,7 +36,7 @@ extension MissingArtwork: Identifiable {
 }
 
 extension MissingArtwork {
-  var simpleRepresentation: String {
+  public var simpleRepresentation: String {
     switch self {
     case let .ArtistAlbum(artist, album):
       return "\(artist) \(album)"

--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -34,11 +34,18 @@ public struct MissingArtworkView: View, ArtworksFetcher {
   @State private var missingArtworks: [(MissingArtwork, ArtworkAvailability)] = []
   @State private var artworks: [MissingArtwork: [Artwork]] = [:]
 
-  public init() {}
+  let partialImageButtonBuilder: (_ missingArtwork: MissingArtwork) -> Button<Text>
+
+  public init(
+    partialImageButtonBuilder: @escaping ((_ missingArtwork: MissingArtwork) -> Button<Text>)
+  ) {
+    self.partialImageButtonBuilder = partialImageButtonBuilder
+  }
 
   public var body: some View {
     DescriptionList(
       fetcher: self,
+      partialImageButtonBuilder: partialImageButtonBuilder,
       missingArtworks: $missingArtworks,
       artworks: $artworks,
       showProgressOverlay: $showProgressOverlay
@@ -99,6 +106,8 @@ public struct MissingArtworkView: View, ArtworksFetcher {
 
 struct MissingArtworkView_Previews: PreviewProvider {
   static var previews: some View {
-    MissingArtworkView()
+    MissingArtworkView { missingArtwork in
+      Button("") {}
+    }
   }
 }


### PR DESCRIPTION
- Add .contextMenu to the Description for items with partial album images.
- Allow client to determine what to show in the .contextMenu as well as what is to be done. -- This is because running AppleScript from a library requires signing and more. It's best to leave this to the client for now!