### PR TITLE
Add ContextMenu builder for flexibility

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -18,9 +18,9 @@ protocol ArtworksFetcher {
   func fetchArtworks(missingArtwork: MissingArtwork, term: String) async throws -> [Artwork]
 }
 
-struct DescriptionList: View {
+struct DescriptionList<Content: View>: View {
   let fetcher: ArtworksFetcher
-  let partialImageButtonBuilder: (_ missingArtwork: MissingArtwork) -> Button<Text>
+  @ViewBuilder let partialImageContextMenuBuilder: (_ missingArtwork: MissingArtwork) -> Content
 
   @State private var filter = FilterCategory.all
   @State private var sortOrder = SortOrder.ascending
@@ -171,7 +171,7 @@ struct DescriptionList: View {
               Description(missingArtwork: missingArtwork, availability: availability)
             }
             .contextMenu {
-              self.partialImageButtonBuilder(missingArtwork)
+              self.partialImageContextMenuBuilder(missingArtwork)
                 .disabled(availability != .some)
             }
             .tag(missingArtwork)
@@ -242,7 +242,7 @@ struct DescriptionList_Previews: PreviewProvider {
   static var previews: some View {
     DescriptionList(
       fetcher: Fetcher(),
-      partialImageButtonBuilder: { missingArtwork in
+      partialImageContextMenuBuilder: { missingArtwork in
         Button("") {}
       },
       missingArtworks: .constant([
@@ -255,7 +255,7 @@ struct DescriptionList_Previews: PreviewProvider {
 
     DescriptionList(
       fetcher: Fetcher(),
-      partialImageButtonBuilder: { missingArtwork in
+      partialImageContextMenuBuilder: { missingArtwork in
         Button("") {
         }
       },

--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -8,7 +8,7 @@
 import MusicKit
 import SwiftUI
 
-public struct MissingArtworkView: View, ArtworksFetcher {
+public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
   struct FetchError: LocalizedError {
     let nsError: NSError
 
@@ -34,18 +34,20 @@ public struct MissingArtworkView: View, ArtworksFetcher {
   @State private var missingArtworks: [(MissingArtwork, ArtworkAvailability)] = []
   @State private var artworks: [MissingArtwork: [Artwork]] = [:]
 
-  let partialImageButtonBuilder: (_ missingArtwork: MissingArtwork) -> Button<Text>
+  @ViewBuilder let partialImageContextMenuBuilder: (_ missingArtwork: MissingArtwork) -> Content
 
   public init(
-    partialImageButtonBuilder: @escaping ((_ missingArtwork: MissingArtwork) -> Button<Text>)
+    @ViewBuilder partialImageContextMenuBuilder: @escaping (
+      (_ missingArtwork: MissingArtwork) -> Content
+    )
   ) {
-    self.partialImageButtonBuilder = partialImageButtonBuilder
+    self.partialImageContextMenuBuilder = partialImageContextMenuBuilder
   }
 
   public var body: some View {
     DescriptionList(
       fetcher: self,
-      partialImageButtonBuilder: partialImageButtonBuilder,
+      partialImageContextMenuBuilder: partialImageContextMenuBuilder,
       missingArtworks: $missingArtworks,
       artworks: $artworks,
       showProgressOverlay: $showProgressOverlay
@@ -106,8 +108,8 @@ public struct MissingArtworkView: View, ArtworksFetcher {
 
 struct MissingArtworkView_Previews: PreviewProvider {
   static var previews: some View {
-    MissingArtworkView { missingArtwork in
+    MissingArtworkView(partialImageContextMenuBuilder: { missingArtwork in
       Button("") {}
-    }
+    })
   }
 }


### PR DESCRIPTION
Use @ViewBuilder and generics to allow the context menu to be completely populated by the client. Prior to this change, it could just be one button. Now it is flexible enough to add more!