### PR TITLE
Use VStack in a ScrollView instead of List

### DIFF
--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -17,8 +17,12 @@ struct MissingImageList: View {
 
   var body: some View {
     GeometryReader { proxy in
-      List(self.artworks ?? []) { artwork in
-        MissingArtworkImage(artwork: artwork, width: proxy.size.width)
+      ScrollView {
+        VStack {
+          ForEach(self.artworks ?? []) { artwork in
+            MissingArtworkImage(artwork: artwork, width: proxy.size.width)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This allows layout of the artwork images to be fully next to the side list and up to the scroll bar. When using List part of this was cutoff on the .trailing, and it was inset on the .leading side.