### PR TITLE
Track Selected Artworks

### DIFF
--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -33,6 +33,7 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
 
   @State private var missingArtworks: [(MissingArtwork, ArtworkAvailability)] = []
   @State private var artworks: [MissingArtwork: [Artwork]] = [:]
+  @State private var selectedArtworks: [MissingArtwork: Artwork] = [:]
 
   @ViewBuilder let partialImageContextMenuBuilder: (_ missingArtwork: MissingArtwork) -> Content
 
@@ -50,6 +51,7 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
       partialImageContextMenuBuilder: partialImageContextMenuBuilder,
       missingArtworks: $missingArtworks,
       artworks: $artworks,
+      selectedArtworks: $selectedArtworks,
       showProgressOverlay: $showProgressOverlay
     )
     .alert(

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -15,7 +15,7 @@ extension Artwork: Identifiable {
 struct MissingImageList: View {
   @Binding var artworks: [Artwork]?
 
-  @State var current: Artwork?
+  @Binding var selectedArtwork: Artwork?
 
   var body: some View {
     GeometryReader { proxy in
@@ -23,8 +23,8 @@ struct MissingImageList: View {
         VStack {
           ForEach(self.artworks ?? []) { artwork in
             MissingArtworkImage(artwork: artwork, width: proxy.size.width)
-              .onTapGesture { current = artwork }
-              .border(.selection, width: current == artwork ? 2.0 : 0)
+              .onTapGesture { selectedArtwork = artwork }
+              .border(.selection, width: selectedArtwork == artwork ? 2.0 : 0)
           }
         }
       }
@@ -36,7 +36,8 @@ struct MissingImageList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
       MissingImageList(
-        artworks: .constant([]))
+        artworks: .constant([]),
+        selectedArtwork: .constant(nil))
     }
   }
 }


### PR DESCRIPTION
This way once an Artwork is selected, it is shown persistently as the user changes what MissingArtwork is selected in the NavigationView.