### PR TITLE
MissingArtworkImage now binds to its NSImage.

### DIFF
--- a/Sources/MissingArtwork/ArtworkImage.swift
+++ b/Sources/MissingArtwork/ArtworkImage.swift
@@ -5,8 +5,10 @@
 //  Created by Greg Bolsinga on 11/17/22.
 //
 
+import AppKit
 import MusicKit
 
 struct ArtworkImage: Equatable {
   let artwork: Artwork
+  var nsImage: NSImage?
 }

--- a/Sources/MissingArtwork/MissingArtworkImage.swift
+++ b/Sources/MissingArtwork/MissingArtworkImage.swift
@@ -5,7 +5,7 @@
 //  Created by Greg Bolsinga on 11/8/22.
 //
 
-@preconcurrency import AppKit
+@preconcurrency import Foundation
 import MusicKit
 import SwiftUI
 
@@ -13,7 +13,7 @@ struct MissingArtworkImage: View {
   let artwork: Artwork
   let width: CGFloat
 
-  @State private var nsImage: NSImage? = nil
+  @Binding var nsImage: NSImage?
   @State private var showProgressOverlay: Bool = true
   @State private var error: Error? = nil
 

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -22,9 +22,11 @@ struct MissingImageList: View {
       ScrollView {
         VStack {
           ForEach($artworkImages, id: \.artwork) { $artworkImage in
-            MissingArtworkImage(artwork: artworkImage.artwork, width: proxy.size.width)
-              .onTapGesture { selectedArtworkImage = artworkImage }
-              .border(.selection, width: selectedArtworkImage == artworkImage ? 2.0 : 0)
+            MissingArtworkImage(
+              artwork: artworkImage.artwork, width: proxy.size.width, nsImage: $artworkImage.nsImage
+            )
+            .onTapGesture { selectedArtworkImage = artworkImage }
+            .border(.selection, width: selectedArtworkImage == artworkImage ? 2.0 : 0)
           }
         }
       }


### PR DESCRIPTION
- It is now stored in ArtworkImage, which is @State in DescriptionList.
- This way the selected NSImage is now able to be surfaced.
- Now that AppKit is imported elsewhere, change the previous import to Foundation.