### PR TITLE
rename menu builder closure and use typealias

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -30,7 +30,10 @@ extension Binding {
 
 struct DescriptionList<Content: View>: View {
   let fetcher: ArtworksFetcher
-  @ViewBuilder let partialImageContextMenuBuilder: (_ missingArtwork: MissingArtwork) -> Content
+
+  typealias ImageContextMenuBuilder = (MissingArtwork) -> Content
+
+  @ViewBuilder let imageContextMenuBuilder: ImageContextMenuBuilder
 
   @State private var filter = FilterCategory.all
   @State private var sortOrder = SortOrder.ascending
@@ -189,7 +192,7 @@ struct DescriptionList<Content: View>: View {
               Description(missingArtwork: missingArtwork, availability: availability)
             }
             .contextMenu {
-              self.partialImageContextMenuBuilder(missingArtwork)
+              self.imageContextMenuBuilder(missingArtwork)
                 .disabled(availability != .some)
             }
             .tag(missingArtwork)
@@ -260,8 +263,9 @@ struct DescriptionList_Previews: PreviewProvider {
   static var previews: some View {
     DescriptionList(
       fetcher: Fetcher(),
-      partialImageContextMenuBuilder: { missingArtwork in
-        Button("") {}
+      imageContextMenuBuilder: { missingArtwork in
+        Button("1") {}
+        Button("2") {}
       },
       missingArtworks: .constant([
         (MissingArtwork.ArtistAlbum("The Stooges", "Fun House"), .none),
@@ -272,9 +276,9 @@ struct DescriptionList_Previews: PreviewProvider {
 
     DescriptionList(
       fetcher: Fetcher(),
-      partialImageContextMenuBuilder: { missingArtwork in
-        Button("") {
-        }
+      imageContextMenuBuilder: { missingArtwork in
+        Button("1") {}
+        Button("2") {}
       },
       missingArtworks: .constant([]),
       showProgressOverlay: .constant(true)

--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -33,20 +33,18 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
 
   @State private var missingArtworks: [(MissingArtwork, ArtworkAvailability)] = []
 
-  @ViewBuilder let partialImageContextMenuBuilder: (_ missingArtwork: MissingArtwork) -> Content
+  public typealias ImageContextMenuBuilder = (MissingArtwork) -> Content
 
-  public init(
-    @ViewBuilder partialImageContextMenuBuilder: @escaping (
-      (_ missingArtwork: MissingArtwork) -> Content
-    )
-  ) {
-    self.partialImageContextMenuBuilder = partialImageContextMenuBuilder
+  @ViewBuilder let imageContextMenuBuilder: ImageContextMenuBuilder
+
+  public init(@ViewBuilder imageContextMenuBuilder: @escaping ImageContextMenuBuilder) {
+    self.imageContextMenuBuilder = imageContextMenuBuilder
   }
 
   public var body: some View {
     DescriptionList(
       fetcher: self,
-      partialImageContextMenuBuilder: partialImageContextMenuBuilder,
+      imageContextMenuBuilder: imageContextMenuBuilder,
       missingArtworks: $missingArtworks,
       showProgressOverlay: $showProgressOverlay
     )
@@ -106,8 +104,9 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
 
 struct MissingArtworkView_Previews: PreviewProvider {
   static var previews: some View {
-    MissingArtworkView(partialImageContextMenuBuilder: { missingArtwork in
-      Button("") {}
+    MissingArtworkView(imageContextMenuBuilder: { missingArtwork in
+      Button("1") {}
+      Button("2") {}
     })
   }
 }


### PR DESCRIPTION
- This is because we're going to start passing more parameters to it to handle non-partial images.
- Filed FB11818254 about not being able to pass more than one @ViewBuilder closure to the init.