### PR TITLE
Add ProcessingState, used to show state of fixing artwork in UI.

### DIFF
--- a/Sources/MissingArtwork/Description.swift
+++ b/Sources/MissingArtwork/Description.swift
@@ -8,13 +8,17 @@
 import SwiftUI
 
 public struct Description: View {
+  public enum ProcessingState {
+    case none  // no action has been taken
+    case processing  // the action is processing
+    case success  // the action has succeeded
+    case failure  // the action has failed.
+  }
+
   let missingArtwork: MissingArtwork
   let availability: ArtworkAvailability
 
-  public init(missingArtwork: MissingArtwork, availability: ArtworkAvailability) {
-    self.missingArtwork = missingArtwork
-    self.availability = availability
-  }
+  @Binding var processingState: ProcessingState
 
   public var body: some View {
     HStack {
@@ -34,6 +38,18 @@ public struct Description: View {
           Image(systemName: "square.stack")
         }
       }
+      switch processingState {
+      case .none:
+        EmptyView()
+      case .processing:
+        Image(systemName: "gearshape.circle")
+      case .success:
+        Image(systemName: "checkmark.circle")
+          .foregroundColor(.green)
+      case .failure:
+        Image(systemName: "circle.slash")
+          .foregroundColor(.red)
+      }
       Spacer()
       switch availability {
       case .some:
@@ -52,15 +68,17 @@ struct Description_Previews: PreviewProvider {
   static var previews: some View {
     Group {
       Description(
-        missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House"), availability: .none)
+        missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House"), availability: .none,
+        processingState: .constant(Description.ProcessingState.none))
       Description(
-        missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House"), availability: .some)
+        missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House"), availability: .some,
+        processingState: .constant(Description.ProcessingState.processing))
       Description(
         missingArtwork: MissingArtwork.CompilationAlbum("Beleza Tropical: Brazil Classics 1"),
-        availability: .none)
+        availability: .none, processingState: .constant(Description.ProcessingState.success))
       Description(
         missingArtwork: MissingArtwork.CompilationAlbum("Beleza Tropical: Brazil Classics 1"),
-        availability: .some)
+        availability: .some, processingState: .constant(Description.ProcessingState.failure))
     }
   }
 }

--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -54,6 +54,8 @@ struct DescriptionList<Content: View>: View {
 
   @Binding var showProgressOverlay: Bool
 
+  @Binding var processingStates: [MissingArtwork: Description.ProcessingState]
+
   var displayableArtworks: [(MissingArtwork, ArtworkAvailability)] {
     return missingArtworks.filter { (missingArtwork, _) in
       (filter == .all
@@ -190,7 +192,10 @@ struct DescriptionList<Content: View>: View {
                 }
               }
             } label: {
-              Description(missingArtwork: missingArtwork, availability: availability)
+              Description(
+                missingArtwork: missingArtwork,
+                availability: availability,
+                processingState: $processingStates[missingArtwork].defaultValue(.none))
             }
             .contextMenu {
               self.imageContextMenuBuilder([
@@ -280,7 +285,11 @@ struct DescriptionList_Previews: PreviewProvider {
         (MissingArtwork.ArtistAlbum("The Stooges", "Fun House"), .none),
         (MissingArtwork.CompilationAlbum("Beleza Tropical: Brazil Classics 1"), .some),
       ]),
-      showProgressOverlay: .constant(false)
+      showProgressOverlay: .constant(false),
+      processingStates: .constant([
+        MissingArtwork.ArtistAlbum("The Stooges", "Fun House"): .processing,
+        MissingArtwork.CompilationAlbum("Beleza Tropical: Brazil Classics 1"): .success,
+      ])
     )
 
     DescriptionList(
@@ -290,7 +299,8 @@ struct DescriptionList_Previews: PreviewProvider {
         Button("2") {}
       },
       missingArtworks: .constant([]),
-      showProgressOverlay: .constant(true)
+      showProgressOverlay: .constant(true),
+      processingStates: .constant([:])
     )
   }
 }

--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -33,6 +33,8 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
 
   @State private var missingArtworks: [(MissingArtwork, ArtworkAvailability)] = []
 
+  @Binding var processingStates: [MissingArtwork: Description.ProcessingState]
+
   public typealias MissingImage = (
     missingArtwork: MissingArtwork, availability: ArtworkAvailability, image: NSImage?
   )
@@ -40,8 +42,12 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
 
   @ViewBuilder let imageContextMenuBuilder: ImageContextMenuBuilder
 
-  public init(@ViewBuilder imageContextMenuBuilder: @escaping ImageContextMenuBuilder) {
+  public init(
+    @ViewBuilder imageContextMenuBuilder: @escaping ImageContextMenuBuilder,
+    processingStates: Binding<[MissingArtwork: Description.ProcessingState]>
+  ) {
     self.imageContextMenuBuilder = imageContextMenuBuilder
+    self._processingStates = processingStates // Note this for assigning a Binding<T> to a wrapped property.
   }
 
   public var body: some View {
@@ -49,7 +55,8 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
       fetcher: self,
       imageContextMenuBuilder: imageContextMenuBuilder,
       missingArtworks: $missingArtworks,
-      showProgressOverlay: $showProgressOverlay
+      showProgressOverlay: $showProgressOverlay,
+      processingStates: $processingStates
     )
     .alert(
       "No Missing Artwork", isPresented: $showNoMissingArtworkFound,
@@ -107,9 +114,10 @@ public struct MissingArtworkView<Content: View>: View, ArtworksFetcher {
 
 struct MissingArtworkView_Previews: PreviewProvider {
   static var previews: some View {
-    MissingArtworkView(imageContextMenuBuilder: { items in
-      Button("1") {}
-      Button("2") {}
-    })
+    MissingArtworkView(
+      imageContextMenuBuilder: { items in
+        Button("1") {}
+        Button("2") {}
+      }, processingStates: .constant([:]))
   }
 }


### PR DESCRIPTION
- It's bound down through the UI. The app will provide the data.