### PR TITLE
Do Not Reload NSImage if already present

### DIFF
--- a/Sources/MissingArtwork/MissingArtworkImage.swift
+++ b/Sources/MissingArtwork/MissingArtworkImage.swift
@@ -68,6 +68,11 @@ struct MissingArtworkImage: View {
     }
     .frame(width: width)
     .task {
+      guard nsImage == nil else {
+        loadingState = .loaded(nsImage!)
+        return
+      }
+
       loadingState = .loading
 
       do {


### PR DESCRIPTION
- Also do not showProgressOverlay until loading
- Also always defer setting showProgressOverlay to false, since it has a default value of true. -- This prevents an always showProgressOverlay == true state