### PR TITLE
Remove .none loading state

### DIFF
--- a/Sources/MissingArtwork/MissingArtworkImage.swift
+++ b/Sources/MissingArtwork/MissingArtworkImage.swift
@@ -27,7 +27,6 @@ extension NoImageError: LocalizedError {
 
 struct MissingArtworkImage: View {
   fileprivate enum LoadingState {
-    case none
     case loading
     case error(Error)
     case loaded(NSImage)
@@ -38,13 +37,11 @@ struct MissingArtworkImage: View {
 
   @Binding var nsImage: NSImage?
 
-  @State private var loadingState: LoadingState = .none
+  @State private var loadingState: LoadingState = .loading
 
   var body: some View {
     Group {
       switch loadingState {
-      case .none:
-        ProgressView()
       case .loading:
         if let backgroundColor = artwork.backgroundColor {
           Color(cgColor: backgroundColor)

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -30,7 +30,6 @@ extension NoArtworkError: LocalizedError {
 
 struct MissingImageList: View {
   fileprivate enum LoadingState: Equatable {
-    case none
     case loading
     case error(Error)
     case loaded
@@ -38,8 +37,6 @@ struct MissingImageList: View {
     static func == (lhs: MissingImageList.LoadingState, rhs: MissingImageList.LoadingState) -> Bool
     {
       switch (lhs, rhs) {
-      case (.none, .none):
-        return true
       case (.loading, .loading):
         return true
       case (.error(_), .error(_)):
@@ -59,10 +56,10 @@ struct MissingImageList: View {
 
   @Binding var selectedArtwork: MissingArtwork?
 
-  @State private var loadingState: LoadingState = .none
+  @State private var loadingState: LoadingState = .loading
 
   @ViewBuilder private var imageListOverlay: some View {
-    if loadingState == .none || loadingState == .loading {
+    if loadingState == .loading {
       ProgressView()
     } else if case .error(let error) = loadingState {
       Text("\(error.localizedDescription)")


### PR DESCRIPTION
- Just start it at .loading, as .none had the same UI