### PR TITLE
Extract WrappedLocalizedError into its own file.

### DIFF
--- a/Sources/MissingArtwork/LoadingState.swift
+++ b/Sources/MissingArtwork/LoadingState.swift
@@ -7,38 +7,6 @@
 
 import Foundation
 
-public enum LoadingStateError: LocalizedError {
-  case localized(LocalizedError)
-
-  public var errorDescription: String? {
-    switch self {
-    case .localized(let error):
-      return error.errorDescription
-    }
-  }
-
-  public var failureReason: String? {
-    switch self {
-    case .localized(let error):
-      return error.failureReason
-    }
-  }
-
-  public var recoverySuggestion: String? {
-    switch self {
-    case .localized(let error):
-      return error.recoverySuggestion
-    }
-  }
-
-  public var helpAnchor: String? {
-    switch self {
-    case .localized(let error):
-      return error.helpAnchor
-    }
-  }
-}
-
 public enum LoadingState<Value> {
   case idle
   case loading
@@ -68,17 +36,9 @@ public enum LoadingState<Value> {
     return false
   }
 
-  public var currentError: LoadingStateError? {
-    // This wrapping LoadingStateError is necessary, as there is a compiler error if this
-    // attempts to return LocalizedError? and the associated value is also LocalizedError.
-    // So it is wrapped in a concrete type to hide this. Definitely not ideal, but can be
-    // revisited in the future.
+  public var currentError: WrappedLocalizedError? {
     if case .error(let error) = self {
-      if let localizedError = error as? LocalizedError {
-        return LoadingStateError.localized(localizedError)
-      } else {
-        return LoadingStateError.localized(error.fallbackLocalizedError)
-      }
+      return WrappedLocalizedError.wrapError(error: error)
     }
     return nil
   }

--- a/Sources/MissingArtwork/WrappedLocalizedError.swift
+++ b/Sources/MissingArtwork/WrappedLocalizedError.swift
@@ -1,0 +1,52 @@
+//
+//  WrappedLocalizedError.swift
+//
+//
+//  Created by Greg Bolsinga on 1/22/23.
+//
+
+import Foundation
+
+public enum WrappedLocalizedError: LocalizedError {
+  case localized(LocalizedError)
+
+  public var errorDescription: String? {
+    switch self {
+    case .localized(let error):
+      return error.errorDescription
+    }
+  }
+
+  public var failureReason: String? {
+    switch self {
+    case .localized(let error):
+      return error.failureReason
+    }
+  }
+
+  public var recoverySuggestion: String? {
+    switch self {
+    case .localized(let error):
+      return error.recoverySuggestion
+    }
+  }
+
+  public var helpAnchor: String? {
+    switch self {
+    case .localized(let error):
+      return error.helpAnchor
+    }
+  }
+
+  public static func wrapError(error: Error) -> WrappedLocalizedError {
+    // This wrapping WrappedLocalizedError is necessary, as there is a compiler error if this
+    // attempts to return LocalizedError? and the associated value is also LocalizedError.
+    // So it is wrapped in a concrete type to hide this. Definitely not ideal, but can be
+    // revisited in the future.
+    if let localizedError = error as? LocalizedError {
+      return WrappedLocalizedError.localized(localizedError)
+    } else {
+      return WrappedLocalizedError.localized(error.fallbackLocalizedError)
+    }
+  }
+}


### PR DESCRIPTION
- move wrapError() into the class.