### PR TITLE
MissingImageList has a single Binding to LoadingState<[(Artwork, LoadingState<NSImage>)]>

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -27,8 +27,8 @@ struct DescriptionList<Content: View>: View {
   @State private var searchString: String = ""
 
   @State private var selectedArtworkImages: [MissingArtwork: NSImage] = [:]
-  @State private var artworkImages: [MissingArtwork: [(Artwork, LoadingState<NSImage>)]] = [:]
-  @State private var artworkLoadingStates: [MissingArtwork: LoadingState<[Artwork]>] = [:]
+  @State private var artworkLoadingStates:
+    [MissingArtwork: LoadingState<[(Artwork, LoadingState<NSImage>)]>] = [:]
 
   let missingArtworks: [MissingArtwork]?
 
@@ -131,7 +131,6 @@ struct DescriptionList<Content: View>: View {
         NavigationLink {
           MissingImageList(
             missingArtwork: missingArtwork,
-            artworkImages: $artworkImages[missingArtwork].defaultValue([]),
             loadingState: $artworkLoadingStates[missingArtwork].defaultValue(.idle),
             selectedArtworkImage: $selectedArtworkImages[missingArtwork]
           )

--- a/Sources/MissingArtwork/LoadingState+Artwork.swift
+++ b/Sources/MissingArtwork/LoadingState+Artwork.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 1/22/23.
 //
 
+import AppKit
 import Foundation
 import MusicKit
 
@@ -21,7 +22,7 @@ extension NoArtworkError: LocalizedError {
   }
 }
 
-extension LoadingState where Value == [Artwork] {
+extension LoadingState where Value == [(Artwork, LoadingState<NSImage>)] {
   private func fetchArtworks(missingArtwork: MissingArtwork, term: String) async throws -> [Artwork]
   {
     var searchRequest = MusicCatalogSearchRequest(term: term, types: [Album.self])
@@ -44,7 +45,7 @@ extension LoadingState where Value == [Artwork] {
         throw NoArtworkError.noneFound(missingArtwork)
       }
 
-      self = .loaded(artworks)
+      self = .loaded(artworks.map { ($0, .idle) })
     } catch {
       self = .error(error)
     }


### PR DESCRIPTION
- This allows less @State variables and it more clear.
- It uses an inline Binding to the LoadingState<>.value for the ForEach!