### PR TITLE
Update to NavigationSplitView

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -128,13 +128,7 @@ struct DescriptionList<Content: View>: View {
   @ViewBuilder private var sidebarView: some View {
     VStack {
       List(displayableArtworks, selection: $selectedArtwork) { missingArtwork in
-        NavigationLink {
-          MissingImageList(
-            missingArtwork: missingArtwork,
-            loadingState: $artworkLoadingStates[missingArtwork].defaultValue(.idle),
-            selectedArtworkImage: $selectedArtworkImages[missingArtwork]
-          )
-        } label: {
+        NavigationLink(value: missingArtwork) {
           Description(
             missingArtwork: missingArtwork,
             processingState: $processingStates[missingArtwork].defaultValue(.none))
@@ -159,7 +153,7 @@ struct DescriptionList<Content: View>: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationSplitView {
       sidebarView
         .navigationTitle(title)
         .frame(minWidth: 325)
@@ -193,10 +187,13 @@ struct DescriptionList<Content: View>: View {
             }
           }
         }
-
-      if displayableArtworks.count > 0 {
-        Text("Select an Item")
-      }
+    } detail: {
+      MissingImageList(
+        missingArtwork: selectedArtwork,
+        loadingState: (selectedArtwork != nil)
+          ? $artworkLoadingStates[selectedArtwork!].defaultValue(.idle) : .constant(.idle),
+        selectedArtworkImage: (selectedArtwork != nil)
+          ? $selectedArtworkImages[selectedArtwork!] : .constant(nil))
     }
   }
 

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -15,7 +15,9 @@ struct MissingImageList: View {
   @Binding var selectedArtworkImage: NSImage?
 
   @ViewBuilder private var imageListOverlay: some View {
-    if loadingState.isIdleOrLoading {
+    if missingArtwork == nil {
+      Text("Select an Item")
+    } else if loadingState.isIdleOrLoading {
       ProgressView()
     } else if case .error(let error) = loadingState {
       Text("\(error.localizedDescription)")
@@ -48,7 +50,7 @@ struct MissingImageList: View {
       }
     }
     .overlay(imageListOverlay)
-    .task {
+    .task(id: missingArtwork) {
       if let missingArtwork {
         await loadingState.load(missingArtwork: missingArtwork)
       }


### PR DESCRIPTION
- MissingImageList.task now takes the id parameter. This is required for this to work out.
- The "Select an Item" prompt moves into the detail view.