### PR TITLE
improve previews for more debugging help

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -230,34 +230,6 @@ struct DescriptionList_Previews: PreviewProvider {
         Button("1") {}
         Button("2") {}
       },
-      missingArtworks: missingArtworks,
-      showProgressOverlay: .constant(false),
-      processingStates: .constant(
-        missingArtworks.reduce(into: [MissingArtwork: Description.ProcessingState]()) {
-          $0[$1] = .success
-        }
-      )
-    )
-
-    DescriptionList(
-      imageContextMenuBuilder: { items in
-        Button("1") {}
-        Button("2") {}
-      },
-      missingArtworks: missingArtworks,
-      showProgressOverlay: .constant(false),
-      processingStates: .constant(
-        missingArtworks.reduce(into: [MissingArtwork: Description.ProcessingState]()) {
-          $0[$1] = .failure
-        }
-      )
-    )
-
-    DescriptionList(
-      imageContextMenuBuilder: { items in
-        Button("1") {}
-        Button("2") {}
-      },
       missingArtworks: [],
       showProgressOverlay: .constant(true),
       processingStates: .constant([:])

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -61,9 +61,25 @@ struct MissingImageList: View {
 struct MissingImageList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
+      let missingArtwork = MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none)
       MissingImageList(
-        missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none),
+        missingArtwork: nil,
         loadingState: .constant(.idle),
+        selectedArtworkImage: .constant(nil))
+
+      MissingImageList(
+        missingArtwork: missingArtwork,
+        loadingState: .constant(.idle),
+        selectedArtworkImage: .constant(nil))
+
+      MissingImageList(
+        missingArtwork: missingArtwork,
+        loadingState: .constant(.loading),
+        selectedArtworkImage: .constant(nil))
+
+      MissingImageList(
+        missingArtwork: missingArtwork,
+        loadingState: .constant(.loaded([])),
         selectedArtworkImage: .constant(nil))
     }
   }


### PR DESCRIPTION
- DescriptionList doesn't need all the ProcessingState variants; they are in Description's Previews.
- MissingImageList now has (I think) all the states, and it is rendering properly.
- I think the bug lies within DescriptionList: I think it should have a @Binding var loadingState : LoadingState<[MissingArtwork]> to fix the bug. Upcoming.