### PR TITLE
MissingImageList now takes non-optional MissingArtwork

### DIFF
--- a/Sources/MissingArtwork/DetailView.swift
+++ b/Sources/MissingArtwork/DetailView.swift
@@ -27,22 +27,18 @@ struct DetailView: View {
     !loadingState.isIdleOrLoading && !missingArtworksIsEmpty
   }
 
-  @ViewBuilder private var detailOverlay: some View {
-    if missingArtworkIsSelectable && selectedArtwork.isEmpty {
-      Text("Select an Item")
-    }
-  }
-
   var body: some View {
-    MissingImageList(
-      missingArtwork: selectedArtwork.first,
-      showStatusOverlay: .constant(missingArtworkIsSelectable && !selectedArtwork.isEmpty),
-      loadingState: (selectedArtwork.first != nil)
-        ? $artworkLoadingStates[selectedArtwork.first!].defaultValue(.idle) : .constant(.idle),
-      selectedArtworkImage: (selectedArtwork.first != nil)
-        ? $selectedArtworkImages[selectedArtwork.first!] : .constant(nil)
-    )
-    .overlay(detailOverlay)
+    if selectedArtwork.isEmpty {
+      if missingArtworkIsSelectable {
+        Text("Select an Item")
+      }
+    } else {
+      MissingImageList(
+        missingArtwork: selectedArtwork.first!,
+        loadingState: $artworkLoadingStates[selectedArtwork.first!].defaultValue(.idle),
+        selectedArtworkImage: $selectedArtworkImages[selectedArtwork.first!]
+      )
+    }
   }
 }
 

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -9,19 +9,16 @@ import MusicKit
 import SwiftUI
 
 struct MissingImageList: View {
-  let missingArtwork: MissingArtwork?
-  @Binding var showStatusOverlay: Bool
+  let missingArtwork: MissingArtwork
   @Binding var loadingState: LoadingState<[(Artwork, LoadingState<NSImage>)]>
 
   @Binding var selectedArtworkImage: NSImage?
 
   @ViewBuilder private var artworkLoadingStatusOverlay: some View {
-    if showStatusOverlay {
-      if loadingState.isIdleOrLoading {
-        ProgressView()
-      } else if case .error(let error) = loadingState {
-        Text("\(error.localizedDescription)")
-      }
+    if loadingState.isIdleOrLoading {
+      ProgressView()
+    } else if case .error(let error) = loadingState {
+      Text("\(error.localizedDescription)")
     }
   }
 
@@ -52,9 +49,7 @@ struct MissingImageList: View {
     }
     .overlay(artworkLoadingStatusOverlay)
     .task(id: missingArtwork) {
-      if let missingArtwork {
-        await loadingState.load(missingArtwork: missingArtwork)
-      }
+      await loadingState.load(missingArtwork: missingArtwork)
     }
   }
 }
@@ -64,32 +59,17 @@ struct MissingImageList_Previews: PreviewProvider {
     Group {
       let missingArtwork = MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none)
       MissingImageList(
-        missingArtwork: nil,
-        showStatusOverlay: .constant(true),
-        loadingState: .constant(.idle),
-        selectedArtworkImage: .constant(nil))
-
-      MissingImageList(
-        missingArtwork: nil,
-        showStatusOverlay: .constant(false),
+        missingArtwork: missingArtwork,
         loadingState: .constant(.idle),
         selectedArtworkImage: .constant(nil))
 
       MissingImageList(
         missingArtwork: missingArtwork,
-        showStatusOverlay: .constant(true),
-        loadingState: .constant(.idle),
-        selectedArtworkImage: .constant(nil))
-
-      MissingImageList(
-        missingArtwork: missingArtwork,
-        showStatusOverlay: .constant(true),
         loadingState: .constant(.loading),
         selectedArtworkImage: .constant(nil))
 
       MissingImageList(
         missingArtwork: missingArtwork,
-        showStatusOverlay: .constant(true),
         loadingState: .constant(.loaded([])),
         selectedArtworkImage: .constant(nil))
     }


### PR DESCRIPTION
- This keeps it simple, and moves the "what should I show?" logic to DetailView.