### PR TITLE
Separate no and partial artwork context menus

### DIFF
--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -8,27 +8,36 @@
 import MusicKit
 import SwiftUI
 
-public struct MissingArtworkView<Content: View>: View {
+public struct MissingArtworkView<
+  NoArtworkContextMenuContent: View, PartialArtworkContextMenuContent: View
+>: View {
   @State private var loadingState: LoadingState<[MissingArtwork]> = .idle
 
   @Binding var processingStates: [MissingArtwork: ProcessingState]
 
-  public typealias ImageContextMenuBuilder = ([(missingArtwork: MissingArtwork, image: NSImage?)])
-    -> Content
+  public typealias NoArtworkContextMenuBuilder = (
+    [(missingArtwork: MissingArtwork, image: NSImage)]
+  ) -> NoArtworkContextMenuContent
+  public typealias PartialArtworkContextMenuBuilder = ([MissingArtwork]) ->
+    PartialArtworkContextMenuContent
 
-  @ViewBuilder let imageContextMenuBuilder: ImageContextMenuBuilder
+  @ViewBuilder let noArtworkContextMenuBuilder: NoArtworkContextMenuBuilder
+  @ViewBuilder let partialArtworkContextMenuBuilder: PartialArtworkContextMenuBuilder
 
   public init(
-    @ViewBuilder imageContextMenuBuilder: @escaping ImageContextMenuBuilder,
+    @ViewBuilder noArtworkContextMenuBuilder: @escaping NoArtworkContextMenuBuilder,
+    @ViewBuilder partialArtworkContextMenuBuilder: @escaping PartialArtworkContextMenuBuilder,
     processingStates: Binding<[MissingArtwork: ProcessingState]>
   ) {
-    self.imageContextMenuBuilder = imageContextMenuBuilder
+    self.noArtworkContextMenuBuilder = noArtworkContextMenuBuilder
+    self.partialArtworkContextMenuBuilder = partialArtworkContextMenuBuilder
     self._processingStates = processingStates  // Note this for assigning a Binding<T> to a wrapped property.
   }
 
   public var body: some View {
     DescriptionList(
-      imageContextMenuBuilder: imageContextMenuBuilder,
+      noArtworkContextMenuBuilder: noArtworkContextMenuBuilder,
+      partialArtworkContextMenuBuilder: partialArtworkContextMenuBuilder,
       loadingState: $loadingState,
       processingStates: $processingStates
     )
@@ -55,7 +64,10 @@ public struct MissingArtworkView<Content: View>: View {
 struct MissingArtworkView_Previews: PreviewProvider {
   static var previews: some View {
     MissingArtworkView(
-      imageContextMenuBuilder: { items in
+      noArtworkContextMenuBuilder: { items in
+        EmptyView()
+      },
+      partialArtworkContextMenuBuilder: { items in
         EmptyView()
       }, processingStates: .constant([:]))
   }

--- a/Sources/MissingArtwork/Resources/en.lproj/Localizable.strings
+++ b/Sources/MissingArtwork/Resources/en.lproj/Localizable.strings
@@ -37,7 +37,8 @@
 /* Recovery message when iTunes is unable to find missing artwork. */
 "iTunes was unable to find any missing artwork to fix." = "iTunes was unable to find any missing artwork to fix.";
 
-/* Help string shown when album artwork does not exist and must be searched for. */
+/* Help string shown when album artwork does not exist and must be searched for.
+Label for the context menu grouping No Artwork actions. */
 "No Artwork" = "No Artwork";
 
 /* Error message when an Image cannot be created from the URL. */
@@ -52,10 +53,14 @@
 /* Error message when MusicKit Artwork does not have an URL. */
 "No Image URL Available: %@." = "No Image URL Available: %@.";
 
+/* Shown when context menu is being shown for No Artwork images and no artwork image has been selected. */
+"No Images Selected" = "No Images Selected";
+
 /* Shown when there is no missing artwork in iTunes */
 "No Missing Artwork" = "No Missing Artwork";
 
-/* Help string shown when album artwork is partially set. */
+/* Help string shown when album artwork is partially set.
+Label for the context menu grouping Partial Artwork actions. */
 "Partial Artwork" = "Partial Artwork";
 
 /* Label in the chart for the quantity of the missing artwork. */


### PR DESCRIPTION
- simplifies things here and on the library client