### PR TITLE
Delay requesting MusicKit Authorization

### DIFF
--- a/Sources/MissingArtwork/AuthorizationView.swift
+++ b/Sources/MissingArtwork/AuthorizationView.swift
@@ -117,11 +117,19 @@ struct AuthorizationView: View {
   }
 
   fileprivate struct SheetPresentationModifier: ViewModifier {
+    @Binding var readyToShowSheet: Bool
+
     @StateObject private var presentationCoordinator = PresentationCoordinator.shared
 
     func body(content: Content) -> some View {
       content
-        .sheet(isPresented: $presentationCoordinator.isAuthorizationSheetPresented) {
+        .sheet(
+          isPresented: Binding<Bool> {
+            return readyToShowSheet && presentationCoordinator.isAuthorizationSheetPresented
+          } set: {
+            presentationCoordinator.isAuthorizationSheetPresented = $0
+          }
+        ) {
           AuthorizationView(
             musicAuthorizationStatus: $presentationCoordinator.musicAuthorizationStatus
           )
@@ -132,8 +140,8 @@ struct AuthorizationView: View {
 }
 
 extension View {
-  @MainActor func musicKitAuthorizationSheet() -> some View {
-    modifier(AuthorizationView.SheetPresentationModifier())
+  @MainActor func musicKitAuthorizationSheet(readyToShowSheet: Binding<Bool>) -> some View {
+    modifier(AuthorizationView.SheetPresentationModifier(readyToShowSheet: readyToShowSheet))
   }
 }
 

--- a/Sources/MissingArtwork/LoadingState+MissingArtwork.swift
+++ b/Sources/MissingArtwork/LoadingState+MissingArtwork.swift
@@ -52,4 +52,11 @@ extension LoadingState where Value == [MissingArtwork] {
       debugPrint("Unable to fetch missing artworks: \(missingError.localizedDescription)")
     }
   }
+
+  public var hasMissingArtwork: Bool {
+    if let missingArtworks = self.value, !missingArtworks.isEmpty {
+      return true
+    }
+    return false
+  }
 }

--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -57,7 +57,7 @@ public struct MissingArtworkView<
     .task {
       await loadingState.load()
     }
-    .musicKitAuthorizationSheet()
+    .musicKitAuthorizationSheet(readyToShowSheet: .constant(loadingState.hasMissingArtwork))
   }
 }
 


### PR DESCRIPTION
- delay it until there are missing artwork found. This way it will not request access if there is nothing to do with those APIs.