### PR TITLE
Wrap InformationListView in ScrollView

### DIFF
--- a/Sources/MissingArtwork/InformationListView.swift
+++ b/Sources/MissingArtwork/InformationListView.swift
@@ -15,13 +15,15 @@ struct InformationListView: View {
   @Binding var processingStates: [MissingArtwork: ProcessingState]
 
   var body: some View {
-    VStack(alignment: .leading) {
-      ForEach(missingArtworks) { missingArtwork in
-        Information(
-          missingArtwork: missingArtwork,
-          imageFound: missingArtworkWithImages.contains(missingArtwork),
-          processingState: processingStates[missingArtwork] != nil
-            ? processingStates[missingArtwork]! : .none)
+    ScrollView {
+      VStack(alignment: .leading) {
+        ForEach(missingArtworks) { missingArtwork in
+          Information(
+            missingArtwork: missingArtwork,
+            imageFound: missingArtworkWithImages.contains(missingArtwork),
+            processingState: processingStates[missingArtwork] != nil
+              ? processingStates[missingArtwork]! : .none)
+        }
       }
     }
   }


### PR DESCRIPTION
- without this, the window becomes gigantic when there are many items. (see #245).