### PR TITLE
Use ArtworkLoadingImage

### DIFF
--- a/Sources/MissingArtwork/ArtworkLoadingImage.swift
+++ b/Sources/MissingArtwork/ArtworkLoadingImage.swift
@@ -1,0 +1,16 @@
+//
+//  ArtworkLoadingImage.swift
+//
+//
+//  Created by Greg Bolsinga on 3/3/23.
+//
+
+import AppKit
+import Foundation
+import LoadingState
+import MusicKit
+
+struct ArtworkLoadingImage {
+  let artwork: Artwork
+  var loadingState: LoadingState<NSImage>
+}

--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -18,8 +18,8 @@ struct DescriptionList: View {
   @State private var searchString: String = ""
 
   @State private var selectedArtworkImages: [MissingArtwork: NSImage] = [:]
-  @State private var artworkLoadingStates:
-    [MissingArtwork: LoadingState<[(Artwork, LoadingState<NSImage>)]>] = [:]
+  @State private var artworkLoadingStates: [MissingArtwork: LoadingState<[ArtworkLoadingImage]>] =
+    [:]
 
   @Binding var loadingState: LoadingState<[MissingArtwork]>
 

--- a/Sources/MissingArtwork/DetailView.swift
+++ b/Sources/MissingArtwork/DetailView.swift
@@ -12,8 +12,7 @@ import SwiftUI
 
 struct DetailView: View {
   @Binding var loadingState: LoadingState<[MissingArtwork]>
-  @Binding var artworkLoadingStates:
-    [MissingArtwork: LoadingState<[(Artwork, LoadingState<NSImage>)]>]
+  @Binding var artworkLoadingStates: [MissingArtwork: LoadingState<[ArtworkLoadingImage]>]
   @Binding var selectedArtworks: Set<MissingArtwork>
   @Binding var selectedArtworkImages: [MissingArtwork: NSImage]
   @Binding var processingStates: [MissingArtwork: ProcessingState]

--- a/Sources/MissingArtwork/LoadingState+Artwork.swift
+++ b/Sources/MissingArtwork/LoadingState+Artwork.swift
@@ -26,7 +26,7 @@ extension NoArtworkError: LocalizedError {
   }
 }
 
-extension LoadingState where Value == [(Artwork, LoadingState<NSImage>)] {
+extension LoadingState where Value == [ArtworkLoadingImage] {
   private func fetchArtworks(missingArtwork: MissingArtwork, term: String) async throws -> [Artwork]
   {
     var searchRequest = MusicCatalogSearchRequest(term: term, types: [Album.self])
@@ -49,7 +49,7 @@ extension LoadingState where Value == [(Artwork, LoadingState<NSImage>)] {
         throw NoArtworkError.noneFound(missingArtwork)
       }
 
-      self = .loaded(artworks.map { ($0, .idle) })
+      self = .loaded(artworks.map { ArtworkLoadingImage(artwork: $0, loadingState: .idle) })
     } catch {
       self = .error(error)
     }

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct MissingImageList: View {
   let missingArtwork: MissingArtwork
-  @Binding var loadingState: LoadingState<[(Artwork, LoadingState<NSImage>)]>
+  @Binding var loadingState: LoadingState<[ArtworkLoadingImage]>
 
   @Binding var selectedArtworkImage: NSImage?
 
@@ -23,8 +23,8 @@ struct MissingImageList: View {
     }
   }
 
-  private var missingArtworkImages: Binding<[(Artwork, LoadingState<NSImage>)]> {
-    Binding<[(Artwork, LoadingState<NSImage>)]> {
+  private var missingArtworkImages: Binding<[ArtworkLoadingImage]> {
+    Binding<[ArtworkLoadingImage]> {
       if let value = loadingState.value {
         return value
       }
@@ -36,14 +36,14 @@ struct MissingImageList: View {
 
   var body: some View {
     GeometryReader { proxy in
-      List(missingArtworkImages, id: \.0) { $artworkImage in
+      List(missingArtworkImages, id: \.artwork) { $artworkImage in
         MissingArtworkImage(
-          width: proxy.size.width, artwork: artworkImage.0,
-          loadingState: $artworkImage.1
+          width: proxy.size.width, artwork: artworkImage.artwork,
+          loadingState: $artworkImage.loadingState
         )
-        .onTapGesture { selectedArtworkImage = artworkImage.1.value }
+        .onTapGesture { selectedArtworkImage = artworkImage.loadingState.value }
         .border(
-          .selection, width: selectedArtworkImage == artworkImage.1.value ? 2.0 : 0)
+          .selection, width: selectedArtworkImage == artworkImage.loadingState.value ? 2.0 : 0)
       }
     }
     .overlay(artworkLoadingStatusOverlay)


### PR DESCRIPTION
- a tuple cannot be made `Equatable` or `Hashable`, which is required for the next step (allowing built-in `List` selection in `MissingImageList`).