### PR TITLE
Revert "enable swift concurrency targeted compiler option (#131)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,6 @@ let package = Package(
       name: "MissingArtwork",
       dependencies: [
         .product(name: "LoadingState", package: "LoadingState")
-      ], swiftSettings: [.unsafeFlags(["-strict-concurrency=targeted"])])
+      ])
   ]
 )


### PR DESCRIPTION
This reverts commit 0ae5fabf3bace0dbfd52d7786baa014db13eb7c6.

This suddenly(?) started to cause build failures in the Missing Artwork application. See https://github.com/bolsinga/MissingArt/actions/runs/4398633053