### PR TITLE
Remove unused AppKit imports / add where NSImage used

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 4/19/22.
 //
 
+import AppKit
 import LoadingState
 import MusicKit
 import SwiftUI

--- a/Sources/MissingArtwork/DetailView.swift
+++ b/Sources/MissingArtwork/DetailView.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 1/27/23.
 //
 
-import AppKit
 import LoadingState
 import MusicKit
 import SwiftUI

--- a/Sources/MissingArtwork/InformationListView.swift
+++ b/Sources/MissingArtwork/InformationListView.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 2/6/23.
 //
 
-import AppKit
 import Foundation
 import SwiftUI
 

--- a/Sources/MissingArtwork/LoadingState+Artwork.swift
+++ b/Sources/MissingArtwork/LoadingState+Artwork.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 1/22/23.
 //
 
-import AppKit
 import Foundation
 import LoadingState
 import MusicKit

--- a/Sources/MissingArtwork/MissingArtworkCommands.swift
+++ b/Sources/MissingArtwork/MissingArtworkCommands.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 3/1/23.
 //
 
+import AppKit
 import SwiftUI
 
 public struct MissingArtworkCommands<

--- a/Sources/MissingArtwork/MissingArtworkImage.swift
+++ b/Sources/MissingArtwork/MissingArtworkImage.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 11/8/22.
 //
 
+import AppKit
 import LoadingState
 import MusicKit
 import SwiftUI


### PR DESCRIPTION
This library needs `NSImage` since it needs to be able to both render the image and pass its data to the client application.