### PR TITLE
Add PlatformImage

### DIFF
--- a/Sources/MissingArtwork/ArtworkLoadingImage.swift
+++ b/Sources/MissingArtwork/ArtworkLoadingImage.swift
@@ -5,12 +5,11 @@
 //  Created by Greg Bolsinga on 3/3/23.
 //
 
-import AppKit
 import Foundation
 import LoadingState
 import MusicKit
 
 struct ArtworkLoadingImage: Equatable, Hashable {
   let artwork: Artwork
-  var loadingState: LoadingState<NSImage>
+  var loadingState: LoadingState<PlatformImage>
 }

--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 4/19/22.
 //
 
-import AppKit
 import LoadingState
 import MusicKit
 import SwiftUI
@@ -74,7 +73,7 @@ struct DescriptionList: View {
     }
   }
 
-  private var noArtSelectedArtworksWithImage: [(MissingArtwork, NSImage)] {
+  private var noArtSelectedArtworksWithImage: [(MissingArtwork, PlatformImage)] {
     noArtSelectedArtworksContainingSelectedAndLoadedImage.map { ($0, $1.loadingState.value!) }
   }
 

--- a/Sources/MissingArtwork/LoadingState+PlatformImage+Artwork.swift
+++ b/Sources/MissingArtwork/LoadingState+PlatformImage+Artwork.swift
@@ -1,11 +1,10 @@
 //
-//  LoadingState+NSImage+Artwork.swift
+//  LoadingState+PlatformImage+Artwork.swift
 //
 //
 //  Created by Greg Bolsinga on 1/21/23.
 //
 
-import AppKit
 import Foundation
 import LoadingState
 import MusicKit
@@ -26,7 +25,7 @@ extension ArtworkImageError: LocalizedError {
   }
 }
 
-extension LoadingState where Value == NSImage {
+extension LoadingState where Value == PlatformImage {
   mutating func load(artwork: Artwork) async {
     do {
       guard let url = artwork.url(width: artwork.maximumWidth, height: artwork.maximumHeight)

--- a/Sources/MissingArtwork/LoadingState+PlatformImage.swift
+++ b/Sources/MissingArtwork/LoadingState+PlatformImage.swift
@@ -1,31 +1,14 @@
 //
-//  LoadingState+NSImage.swift
+//  LoadingState+PlatformImage.swift
 //
 //
 //  Created by Greg Bolsinga on 1/20/23.
 //
 
-import AppKit
 import Foundation
 import LoadingState
 
-private enum NSImageError: Error {
-  case noImage
-}
-
-extension NSImageError: LocalizedError {
-  fileprivate var errorDescription: String? {
-    switch self {
-    case .noImage:
-      return String(
-        localized: "No Image Created.",
-        bundle: .module,
-        comment: "Error message when an Image cannot be created from the URL.")
-    }
-  }
-}
-
-extension LoadingState where Value == NSImage {
+extension LoadingState where Value == PlatformImage {
   mutating func load(url: URL) async {
     guard case .idle = self else {
       return
@@ -35,20 +18,14 @@ extension LoadingState where Value == NSImage {
 
     do {
       let (data, _) = try await URLSession.shared.data(from: url)
-      let nsImage = NSImage.init(data: data)
-
-      if let nsImage {
-        self = .loaded(nsImage)
-      } else {
-        throw NSImageError.noImage
-      }
+      self = .loaded(try PlatformImage(data: data))
     } catch {
       self = .error(error)
     }
   }
 }
 
-extension LoadingState: Equatable where Value == NSImage {
+extension LoadingState: Equatable where Value == PlatformImage {
   public static func == (lhs: LoadingState<Value>, rhs: LoadingState<Value>) -> Bool {
     switch (lhs, rhs) {
     case (.idle, .idle):
@@ -65,7 +42,7 @@ extension LoadingState: Equatable where Value == NSImage {
   }
 }
 
-extension LoadingState: Hashable where Value == NSImage {
+extension LoadingState: Hashable where Value == PlatformImage {
   public func hash(into hasher: inout Hasher) {
     switch self {
     case .idle:
@@ -74,8 +51,8 @@ extension LoadingState: Hashable where Value == NSImage {
       hasher.combine("loading")
     case .error(let error):
       hasher.combine(error.localizedDescription)  // Questionable.
-    case .loaded(let nsImage):
-      hasher.combine(nsImage)
+    case .loaded(let platformImage):
+      hasher.combine(platformImage)
     }
   }
 }

--- a/Sources/MissingArtwork/MissingArtworkCommands.swift
+++ b/Sources/MissingArtwork/MissingArtworkCommands.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 3/1/23.
 //
 
-import AppKit
 import SwiftUI
 
 public struct MissingArtworkCommands<
@@ -16,7 +15,7 @@ public struct MissingArtworkCommands<
   @FocusedBinding(\.noArtworks) var noArtworks
 
   public typealias NoArtworkContextMenuBuilder = (
-    [(missingArtwork: MissingArtwork, image: NSImage)]
+    [(missingArtwork: MissingArtwork, image: PlatformImage)]
   ) -> NoArtworkContextMenuContent
   public typealias PartialArtworkContextMenuBuilder = ([MissingArtwork]) ->
     PartialArtworkContextMenuContent
@@ -66,7 +65,7 @@ private struct PartialArtworksKey: FocusedValueKey {
 }
 
 private struct NoArtworksKey: FocusedValueKey {
-  typealias Value = Binding<[(MissingArtwork, NSImage)]>
+  typealias Value = Binding<[(MissingArtwork, PlatformImage)]>
 }
 
 extension FocusedValues {
@@ -75,7 +74,7 @@ extension FocusedValues {
     set { self[PartialArtworksKey.self] = newValue }
   }
 
-  var noArtworks: Binding<[(MissingArtwork, NSImage)]>? {
+  var noArtworks: Binding<[(MissingArtwork, PlatformImage)]>? {
     get { self[NoArtworksKey.self] }
     set { self[NoArtworksKey.self] = newValue }
   }

--- a/Sources/MissingArtwork/MissingArtworkImage.swift
+++ b/Sources/MissingArtwork/MissingArtworkImage.swift
@@ -5,7 +5,6 @@
 //  Created by Greg Bolsinga on 11/8/22.
 //
 
-import AppKit
 import LoadingState
 import MusicKit
 import SwiftUI
@@ -14,7 +13,7 @@ struct MissingArtworkImage: View {
   let width: CGFloat
 
   let artwork: Artwork
-  @Binding var loadingState: LoadingState<NSImage>
+  @Binding var loadingState: LoadingState<PlatformImage>
 
   var body: some View {
     Group {
@@ -30,8 +29,8 @@ struct MissingArtworkImage: View {
         Text(
           "Unable to load image: \(error.localizedDescription)", bundle: .module,
           comment: "Message when an image URL cannot be loaded.")
-      case .loaded(let nsImage):
-        Image(nsImage: nsImage)
+      case .loaded(let platformImage):
+        platformImage.representingImage
           .resizable().aspectRatio(contentMode: .fit)
       }
     }

--- a/Sources/MissingArtwork/PlatformImage.swift
+++ b/Sources/MissingArtwork/PlatformImage.swift
@@ -1,0 +1,62 @@
+//
+//  PlatformImage.swift
+//
+//
+//  Created by Greg Bolsinga on 3/12/23.
+//
+
+import Foundation
+import SwiftUI
+
+#if canImport(AppKit)
+  import AppKit
+#elseif canImport(UIKit)
+  import UIKit
+#endif
+
+private enum PlatformImageError: Error {
+  case noImage
+}
+
+extension PlatformImageError: LocalizedError {
+  fileprivate var errorDescription: String? {
+    switch self {
+    case .noImage:
+      return String(
+        localized: "No Image Created.",
+        bundle: .module,
+        comment: "Error message when an Image cannot be created from the data.")
+    }
+  }
+}
+
+public struct PlatformImage: Equatable, Hashable {
+  #if canImport(AppKit)
+    public let image: NSImage
+  #elseif canImport(UIKit)
+    public let image: UIImage
+  #endif
+
+  init(data: Data) throws {
+    #if canImport(AppKit)
+      guard let image = NSImage(data: data) else {
+        throw PlatformImageError.noImage
+      }
+    #elseif canImport(UIKit)
+      guard let image = UIImage(data: data) else {
+        throw PlatformImageError.noImage
+      }
+    #endif
+    self.image = image
+  }
+}
+
+extension PlatformImage {
+  @ViewBuilder var representingImage: Image {
+    #if canImport(AppKit)
+      Image(nsImage: image)
+    #elseif canImport(UIKit)
+      Image(uiImage: image)
+    #endif
+  }
+}


### PR DESCRIPTION
This abstracts away `NSImage` vs. `UIImage` in this library for future iOS support. This is necessary compared to `Image` from SwiftUI because:
- Access to the underlying bits `URL` and `Data` are required for debugging and fixing up in the client.