### PR TITLE
Do not load partial artwork from catalog

### DIFF
--- a/Sources/MissingArtwork/DetailView.swift
+++ b/Sources/MissingArtwork/DetailView.swift
@@ -41,11 +41,10 @@ struct DetailView: View {
       }
     } else {
       if selectedArtworks.count == 1, let artwork = selectedArtworks.first {
-        MissingImageList(
+        SingleSelectedMissingArtworkView(
           missingArtwork: artwork,
           loadingState: $artworkLoadingStates[artwork].defaultValue(.idle),
-          selectedArtworkImage: $selectedArtworkImages[artwork]
-        )
+          selectedArtworkImage: $selectedArtworkImages[artwork])
       } else {
         InformationListView(
           missingArtworks: Array(selectedArtworks).sorted(by: sortOrder),

--- a/Sources/MissingArtwork/Resources/en.lproj/Localizable.strings
+++ b/Sources/MissingArtwork/Resources/en.lproj/Localizable.strings
@@ -66,6 +66,9 @@ Label for the context menu grouping No Artwork actions. */
 Label for the context menu grouping Partial Artwork actions. */
 "Partial Artwork" = "Partial Artwork";
 
+/* Text shown when a partial artwork is selected. */
+"Partial Artwork Is Already Ready To Repair" = "Partial Artwork Is Already Ready To Repair";
+
 /* Label in the chart for the quantity of the missing artwork. */
 "Quantity" = "Quantity";
 

--- a/Sources/MissingArtwork/SingleSelectedMissingArtworkView.swift
+++ b/Sources/MissingArtwork/SingleSelectedMissingArtworkView.swift
@@ -1,0 +1,41 @@
+//
+//  SingleSelectedMissingArtworkView.swift
+//
+//
+//  Created by Greg Bolsinga on 3/17/23.
+//
+
+import LoadingState
+import SwiftUI
+
+struct SingleSelectedMissingArtworkView: View {
+  let missingArtwork: MissingArtwork
+  @Binding var loadingState: LoadingState<[ArtworkLoadingImage]>
+  @Binding var selectedArtworkImage: ArtworkLoadingImage?
+
+  var body: some View {
+    if missingArtwork.availability == .some {
+      Text(
+        "Partial Artwork Is Already Ready To Repair", bundle: .module,
+        comment: "Text shown when a partial artwork is selected."
+      ).font(.headline)
+    } else {
+      MissingImageList(
+        missingArtwork: missingArtwork,
+        loadingState: $loadingState,
+        selectedArtworkImage: $selectedArtworkImage
+      )
+    }
+  }
+}
+
+struct SingleSelectedMissingArtworkView_Previews: PreviewProvider {
+  static var previews: some View {
+    let missingArtwork = MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none)
+
+    SingleSelectedMissingArtworkView(
+      missingArtwork: missingArtwork,
+      loadingState: .constant(.idle),
+      selectedArtworkImage: .constant(nil))
+  }
+}


### PR DESCRIPTION
Just show a string that tells the user it is ready for repair.