### PR TITLE
For Partial Image Artworks, display iTunes image

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -20,6 +20,9 @@ struct DescriptionList: View {
   @State private var artworkLoadingStates: [MissingArtwork: LoadingState<[ArtworkLoadingImage]>] =
     [:]
 
+  @State private var partialArtworkImageLoadingStates:
+    [MissingArtwork: LoadingState<PlatformImage>] = [:]
+
   let loadingState: LoadingState<[MissingArtwork]>
 
   @Binding var processingStates: [MissingArtwork: ProcessingState]
@@ -140,7 +143,8 @@ struct DescriptionList: View {
         selectedArtworks: selectedArtworks,
         selectedArtworkImages: $selectedArtworkImages,
         processingStates: $processingStates,
-        sortOrder: sortOrder)
+        sortOrder: sortOrder,
+        partialArtworkImageLoadingStates: $partialArtworkImageLoadingStates)
     }.onChange(of: availabilityFilter) { _ in
       clearSelectionIfNotDisplayable()
     }.onChange(of: searchString) { _ in

--- a/Sources/MissingArtwork/DetailView.swift
+++ b/Sources/MissingArtwork/DetailView.swift
@@ -15,6 +15,7 @@ struct DetailView: View {
   @Binding var selectedArtworkImages: [MissingArtwork: ArtworkLoadingImage]
   @Binding var processingStates: [MissingArtwork: ProcessingState]
   let sortOrder: SortOrder
+  @Binding var partialArtworkImageLoadingStates: [MissingArtwork: LoadingState<PlatformImage>]
 
   private var missingArtworksIsEmpty: Bool {
     if let missingArtworks = loadingState.value {
@@ -45,7 +46,8 @@ struct DetailView: View {
           missingArtwork: artwork,
           loadingState: $artworkLoadingStates[artwork].defaultValue(.idle),
           selectedArtworkImage: $selectedArtworkImages[artwork],
-          processingState: $processingStates[artwork].defaultValue(.none))
+          processingState: $processingStates[artwork].defaultValue(.none),
+          partialImageLoadingState: $partialArtworkImageLoadingStates[artwork].defaultValue(.idle))
       } else {
         InformationListView(
           missingArtworks: Array(selectedArtworks).sorted(by: sortOrder),
@@ -70,7 +72,8 @@ struct DetailView_Previews: PreviewProvider {
       selectedArtworks: [],
       selectedArtworkImages: .constant([:]),
       processingStates: .constant([:]),
-      sortOrder: .ascending)
+      sortOrder: .ascending,
+      partialArtworkImageLoadingStates: .constant([:]))
 
     DetailView(
       loadingState: .loaded([missingArtwork]),
@@ -78,7 +81,8 @@ struct DetailView_Previews: PreviewProvider {
       selectedArtworks: [],
       selectedArtworkImages: .constant([:]),
       processingStates: .constant([missingArtwork: .none]),
-      sortOrder: .ascending)
+      sortOrder: .ascending,
+      partialArtworkImageLoadingStates: .constant([:]))
 
     DetailView(
       loadingState: .loaded([missingArtwork]),
@@ -86,7 +90,8 @@ struct DetailView_Previews: PreviewProvider {
       selectedArtworks: [missingArtwork],
       selectedArtworkImages: .constant([:]),
       processingStates: .constant([missingArtwork: .none]),
-      sortOrder: .ascending)
+      sortOrder: .ascending,
+      partialArtworkImageLoadingStates: .constant([:]))
 
     DetailView(
       loadingState: .loaded([missingArtwork]),
@@ -94,6 +99,7 @@ struct DetailView_Previews: PreviewProvider {
       selectedArtworks: [missingArtwork],
       selectedArtworkImages: .constant([:]),
       processingStates: .constant([missingArtwork: .none]),
-      sortOrder: .ascending)
+      sortOrder: .ascending,
+      partialArtworkImageLoadingStates: .constant([:]))
   }
 }

--- a/Sources/MissingArtwork/LoadingState+PlatformImage.swift
+++ b/Sources/MissingArtwork/LoadingState+PlatformImage.swift
@@ -23,6 +23,22 @@ extension LoadingState where Value == PlatformImage {
       self = .error(error)
     }
   }
+
+  mutating func loadImage(missingArtwork: MissingArtwork) async {
+    guard case .idle = self else {
+      return
+    }
+
+    self = .loading
+
+    do {
+      let image = try await missingArtwork.matchingPartialArtworkImage()
+
+      self = .loaded(image)
+    } catch {
+      self = .error(error)
+    }
+  }
 }
 
 extension LoadingState: Equatable where Value == PlatformImage {

--- a/Sources/MissingArtwork/PartialArtworkImageView.swift
+++ b/Sources/MissingArtwork/PartialArtworkImageView.swift
@@ -1,0 +1,39 @@
+//
+//  PartialArtworkImageView.swift
+//
+//
+//  Created by Greg Bolsinga on 3/19/23.
+//
+
+import LoadingState
+import SwiftUI
+
+struct PartialArtworkImageView: View {
+  let width: CGFloat
+  let missingArtwork: MissingArtwork
+  @Binding var loadingState: LoadingState<PlatformImage>
+
+  var body: some View {
+    VStack(alignment: .center) {
+      Text(
+        "Partial Artwork Is Already Ready To Repair", bundle: .module,
+        comment: "Text shown when a partial artwork is selected."
+      ).font(.headline)
+      switch loadingState {
+      case .idle:
+        ProgressView()
+      case .loading:
+        ProgressView()
+      case .error(_):
+        EmptyView()
+      case .loaded(let platformImage):
+        platformImage.representingImage
+          .resizable().aspectRatio(contentMode: .fit)
+      }
+    }
+    .frame(width: width)
+    .task(id: missingArtwork) {
+      await loadingState.loadImage(missingArtwork: missingArtwork)
+    }
+  }
+}

--- a/Sources/MissingArtwork/PlatformImage.swift
+++ b/Sources/MissingArtwork/PlatformImage.swift
@@ -49,6 +49,16 @@ public struct PlatformImage: Equatable, Hashable {
     #endif
     self.image = image
   }
+
+  #if canImport(AppKit)
+    init(image: NSImage) {
+      self.image = image
+    }
+  #elseif canImport(UIKit)
+    init(image: UIImage) {
+      self.image = image
+    }
+  #endif
 }
 
 extension PlatformImage {

--- a/Sources/MissingArtwork/SingleSelectedMissingArtworkView.swift
+++ b/Sources/MissingArtwork/SingleSelectedMissingArtworkView.swift
@@ -13,16 +13,18 @@ struct SingleSelectedMissingArtworkView: View {
   @Binding var loadingState: LoadingState<[ArtworkLoadingImage]>
   @Binding var selectedArtworkImage: ArtworkLoadingImage?
   @Binding var processingState: ProcessingState
+  @Binding var partialImageLoadingState: LoadingState<PlatformImage>
 
   var body: some View {
     if processingState != .none {
       ProcessingStateView(missingArtwork: missingArtwork, processingState: processingState)
     } else {
       if missingArtwork.availability == .some {
-        Text(
-          "Partial Artwork Is Already Ready To Repair", bundle: .module,
-          comment: "Text shown when a partial artwork is selected."
-        ).font(.headline)
+        GeometryReader { proxy in
+          PartialArtworkImageView(
+            width: proxy.size.width,
+            missingArtwork: missingArtwork, loadingState: $partialImageLoadingState)
+        }
       } else {
         MissingImageList(
           missingArtwork: missingArtwork,
@@ -45,18 +47,21 @@ struct SingleSelectedMissingArtworkView_Previews: PreviewProvider {
       missingArtwork: missingArtworks[0],
       loadingState: .constant(.idle),
       selectedArtworkImage: .constant(nil),
-      processingState: .constant(.none))
+      processingState: .constant(.none),
+      partialImageLoadingState: .constant(.idle))
 
     SingleSelectedMissingArtworkView(
       missingArtwork: missingArtworks[1],
       loadingState: .constant(.idle),
       selectedArtworkImage: .constant(nil),
-      processingState: .constant(.none))
+      processingState: .constant(.none),
+      partialImageLoadingState: .constant(.idle))
 
     SingleSelectedMissingArtworkView(
       missingArtwork: missingArtworks[1],
       loadingState: .constant(.idle),
       selectedArtworkImage: .constant(nil),
-      processingState: .constant(.processing))
+      processingState: .constant(.processing),
+      partialImageLoadingState: .constant(.idle))
   }
 }


### PR DESCRIPTION
- This will allow the user to see what image will be used since it is already there.
- State is held high up the view hierarchy, and the Binding is passed around.