### PR TITLE
Request MusicKit Authorization early if necessary.

### DIFF
--- a/Sources/MissingArtwork/MissingArtworkView.swift
+++ b/Sources/MissingArtwork/MissingArtworkView.swift
@@ -37,7 +37,11 @@ public struct MissingArtworkView: View {
     .task {
       await loadingState.load()
     }
-    .musicKitAuthorizationSheet(readyToShowSheet: .constant(loadingState.hasMissingArtwork))
+    #if os(macOS)
+      .musicKitAuthorizationSheet(readyToShowSheet: .constant(loadingState.hasMissingArtwork))
+    #else
+      .musicKitAuthorizationSheet(readyToShowSheet: .constant(true))
+    #endif
   }
 }
 


### PR DESCRIPTION
- macOS uses iTunes to learn if there are missing artwork, and then needs MusicKit.
- iOS will use MusicKit to learn, so it needs auth right away.