### PR TITLE
Indicate that image search was unable to find images

### DIFF
--- a/Sources/MissingArtwork/LoadingState+Artwork.swift
+++ b/Sources/MissingArtwork/LoadingState+Artwork.swift
@@ -18,7 +18,7 @@ extension NoArtworkError: LocalizedError {
     switch self {
     case .noneFound(let missingArtwork):
       return String(
-        localized: "No image for \(missingArtwork.description)",
+        localized: "Image Search was unable to find images for \(missingArtwork.description)",
         bundle: .module,
         comment: "Error message when no Missing Artworks are found.")
     }

--- a/Sources/MissingArtwork/Resources/en.lproj/Localizable.strings
+++ b/Sources/MissingArtwork/Resources/en.lproj/Localizable.strings
@@ -40,6 +40,9 @@
 /* Help string shown when image is ready for fixing. */
 "Image Ready" = "Image Ready";
 
+/* Error message when no Missing Artworks are found. */
+"Image Search was unable to find images for %@" = "Image Search was unable to find images for %@";
+
 /* Error message when iTunes is unable to find missing artwork. */
 "iTunes Library unable to find missing artwork: %@" = "iTunes Library unable to find missing artwork: %@";
 
@@ -55,9 +58,6 @@ Label for the context menu grouping No Artwork actions. */
 
 /* Error message when an Image cannot be created from the data. */
 "No Image Created." = "No Image Created.";
-
-/* Error message when no Missing Artworks are found. */
-"No image for %@" = "No image for %@";
 
 /* Help string shown when no image has been selected for fixing. */
 "No Image Selected" = "No Image Selected";


### PR DESCRIPTION
- Provide more clarity about why artwork is unable to be fixed.