### PR TITLE
Fix a StrictConcurrency warning

### DIFF
--- a/Sources/MissingArtwork/DescriptionList.swift
+++ b/Sources/MissingArtwork/DescriptionList.swift
@@ -102,6 +102,7 @@ struct DescriptionList: View {
     }
   }
 
+  @MainActor
   @ViewBuilder private var sidebarView: some View {
     VStack {
       List(displayableArtworks, selection: $selectedArtworks) { missingArtwork in


### PR DESCRIPTION
```
/Users/bolsinga/Documents/code/git/itunes_missing_artwork/Sources/MissingArtwork/DescriptionList.swift:107:7: error: call to main actor-isolated initializer 'init(_:selection:rowContent:)' in a synchronous nonisolated context
      List(displayableArtworks, selection: $selectedArtworks) { missingArtwork in
      ^
SwiftUI.List:4:23: note: calls to initializer 'init(_:selection:rowContent:)' from outside of its actor context are implicitly asynchronous
    @MainActor public init<Data, RowContent>(_ data: Data, selection: Binding<Set<SelectionValue>>?, @ViewBuilder rowContent: @escaping (Data.Element) -> RowContent) where Content == ForEach<Data, Data.Element.ID, RowContent>, Data : RandomAccessCollection, RowContent : View, Data.Element : Identifiable
```

Work towards #315 