### PR TITLE
Improve MissingImageList Previews

### DIFF
--- a/Sources/MissingArtwork/ArtworkLoadingImage.swift
+++ b/Sources/MissingArtwork/ArtworkLoadingImage.swift
@@ -8,7 +8,9 @@
 import Foundation
 import MusicKit
 
-struct ArtworkLoadingImage: Equatable, Hashable, Sendable {
-  let artwork: Artwork
-  var loadingState: ArtworkPlatformImageModel
+struct LoadingImage<A: MissingArtworkProtocol>: Equatable, Hashable, Sendable {
+  let artwork: A
+  var loadingState: LoadingModel<PlatformImage, A>
 }
+
+typealias ArtworkLoadingImage = LoadingImage<Artwork>

--- a/Sources/MissingArtwork/MissingArtworkImage.swift
+++ b/Sources/MissingArtwork/MissingArtworkImage.swift
@@ -9,7 +9,7 @@ import MusicKit
 import SwiftUI
 
 // Created so Previews may use fake Artwork.
-protocol MissingArtworkProtocol: Sendable {
+protocol MissingArtworkProtocol: Hashable, Sendable {
   var backgroundColor: CGColor? { get }
   var maximumHeight: Int { get }
 }

--- a/Sources/MissingArtwork/MissingImageList.swift
+++ b/Sources/MissingArtwork/MissingImageList.swift
@@ -8,96 +8,134 @@
 import MusicKit
 import SwiftUI
 
-struct MissingImageList: View {
+struct MissingImageList<C: MissingArtworkProtocol>: View {
   let missingArtwork: MissingArtwork
-  var loadingState: MissingArtworkLoadingImageModel
+  var loadingState: LoadingModel<[LoadingImage<C>], MissingArtwork>
 
-  @Binding var selectedArtworkImage: ArtworkLoadingImage?
-
-  @ViewBuilder private var artworkLoadingStatusOverlay: some View {
-    if loadingState.isIdleOrLoading {
-      ProgressView()
-    } else if let error = loadingState.error {
-      VStack(alignment: .center) {
-        Text(error.localizedDescription)
-        if error as? NoArtworkError == nil {
-          Button {
-            Task {
-              await loadingState.reload(missingArtwork)
-            }
-          } label: {
-            Text(
-              "Retry Loading Image", bundle: .module,
-              comment: "Button title to retry loading an image.")
-          }
-        }
-      }
-    }
-  }
+  @Binding var selectedArtworkImage: LoadingImage<C>?
 
   var body: some View {
     VStack {
-      if missingArtwork.availability == .none, loadingState.value != nil {
-        Text(
-          "Select an Image to Use for Repair", bundle: .module,
-          comment: "Shown when Missing Image List has images for a missing artwork with no artwork."
-        )
-        .font(.headline)
-        .padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
-      }
-      if let values = loadingState.value {
-        GeometryReader { proxy in
-          List(values, id: \.artwork, selection: $selectedArtworkImage) {
-            artworkImage in
-            MissingArtworkImage(
-              width: proxy.size.width, artwork: artworkImage.artwork,
-              loadingState: artworkImage.loadingState
+      if loadingState.isIdleOrLoading {
+        ProgressView()
+      } else if let error = loadingState.error {
+        VStack(alignment: .center) {
+          Text(error.localizedDescription)
+          if error as? NoArtworkError == nil {
+            Button {
+              Task { await loadingState.reload(missingArtwork) }
+            } label: {
+              Text(
+                "Retry Loading Image", bundle: .module,
+                comment: "Button title to retry loading an image.")
+            }
+          }
+        }
+      } else if let values = loadingState.value {
+        if values.isEmpty {
+          Text(
+            "No Images Available", bundle: .module,
+            comment: "Shown when no images are loaded for repair.")
+        } else {
+          if missingArtwork.availability == .none {
+            Text(
+              "Select an Image to Use for Repair", bundle: .module,
+              comment:
+                "Shown when Missing Image List has images for a missing artwork with no artwork."
             )
-            .tag(artworkImage)
+            .font(.headline)
+            .padding(EdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0))
+          }
+          GeometryReader { proxy in
+            List(values, id: \.artwork, selection: $selectedArtworkImage) {
+              artworkImage in
+              MissingArtworkImage(
+                width: proxy.size.width, artwork: artworkImage.artwork,
+                loadingState: artworkImage.loadingState
+              )
+              .tag(artworkImage)
+            }
           }
         }
       }
     }
-    .overlay(artworkLoadingStatusOverlay)
-    .task(id: missingArtwork) {
-      await loadingState.load(missingArtwork)
-    }
+    .task(id: missingArtwork) { await loadingState.load(missingArtwork) }
   }
 }
 
-#Preview {
-  MissingImageList(
-    missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none),
-    loadingState: MissingArtworkLoadingImageModel(),
-    selectedArtworkImage: .constant(nil))
+private struct PreviewArtwork: MissingArtworkProtocol {
+  var backgroundColor: CGColor?
+  var maximumHeight: Int { 300 }
+
+  internal init(backgroundColor: CGColor? = CGColor(red: 0.5, green: 0.5, blue: 1.0, alpha: 1.0)) {
+    self.backgroundColor = backgroundColor
+  }
 }
 
-#Preview {
-  MissingImageList(
+#if canImport(UIKit)
+  private let image = UIImage(systemName: "pencil.circle")
+#else
+  private let image = NSImage(systemSymbolName: "pencil.circle", accessibilityDescription: nil)
+#endif
+
+#Preview("Loading") {
+  MissingImageList<Artwork>(
     missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none),
-    loadingState: MissingArtworkLoadingImageModel(),
-    selectedArtworkImage: .constant(nil))
+    loadingState: LoadingModel(),
+    selectedArtworkImage: .constant(nil)
+  )
+  .frame(width: 300, height: 300)
 }
 
-#Preview {
-  MissingImageList(
+#Preview("Loaded Empty") {
+  MissingImageList<Artwork>(
     missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none),
-    loadingState: MissingArtworkLoadingImageModel(item: []),
-    selectedArtworkImage: .constant(nil))
+    loadingState: LoadingModel(item: []),
+    selectedArtworkImage: .constant(nil)
+  )
+  .frame(width: 300, height: 300)
 }
 
-#Preview {
+#Preview("Loaded Values - Availability None") {
+  MissingImageList(
+    missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none),
+    loadingState: LoadingModel(item: [
+      LoadingImage(
+        artwork: PreviewArtwork(), loadingState: LoadingModel(item: PlatformImage(image: image!)))
+    ]),
+    selectedArtworkImage: .constant(nil)
+  )
+  .frame(width: 300, height: 300)
+}
+
+#Preview("Loaded Values - Availability Some") {
+  MissingImageList(
+    missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .some),
+    loadingState: LoadingModel(item: [
+      LoadingImage(
+        artwork: PreviewArtwork(), loadingState: LoadingModel(item: PlatformImage(image: image!)))
+    ]),
+    selectedArtworkImage: .constant(nil)
+  )
+  .frame(width: 300, height: 300)
+}
+
+#Preview("Error - NoArtworkError") {
   let missingArtwork = MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none)
-  MissingImageList(
+  MissingImageList<Artwork>(
     missingArtwork: missingArtwork,
-    loadingState: MissingArtworkLoadingImageModel(
+    loadingState: LoadingModel(
       error: NoArtworkError.noneFound(missingArtwork.simpleRepresentation)),
-    selectedArtworkImage: .constant(nil))
+    selectedArtworkImage: .constant(nil)
+  )
+  .frame(width: 300, height: 300)
 }
 
-#Preview {
-  MissingImageList(
+#Preview("Error") {
+  MissingImageList<Artwork>(
     missingArtwork: MissingArtwork.ArtistAlbum("The Stooges", "Fun House", .none),
-    loadingState: MissingArtworkLoadingImageModel(error: CancellationError()),
-    selectedArtworkImage: .constant(nil))
+    loadingState: LoadingModel(error: CancellationError()),
+    selectedArtworkImage: .constant(nil)
+  )
+  .frame(width: 300, height: 300)
 }

--- a/Sources/MissingArtwork/Resources/Localizable.xcstrings
+++ b/Sources/MissingArtwork/Resources/Localizable.xcstrings
@@ -96,6 +96,9 @@
     "No Image URL Available: %@." : {
       "comment" : "Error message when MusicKit Artwork does not have an URL."
     },
+    "No Images Available" : {
+      "comment" : "Shown when no images are loaded for repair."
+    },
     "No Images Selected" : {
       "comment" : "Shown when context menu is being shown for No Artwork images and no artwork image has been selected."
     },


### PR DESCRIPTION
- remove the overlays when there is an error.
- add ui when there are no images loaded.
- use and improve generic protocols from #349 to genericify this View for previews too.